### PR TITLE
fix: postgres env var and packages in workspaces config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 *.ddb
 *.ddb.wal
 .vscode/
+*.DS_Store

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -30,6 +30,6 @@ DROPBOX_CLIENT_SECRET=""
 GOOGLE_REDIRECT_URI="http://localhost:8000/googledrive/oauth/callback"
 
 # The following envs depends on your docker compose setup
-POSTGTRES_URL="postgresql://postgres:mysecretpassword@localhost:5433/rocksky"
+POSTGRES_URL="postgresql://postgres:mysecretpassword@localhost:5433/rocksky"
 MEILISEARCH_API_KEY="masterkey"
 REDIS_URL="redis://localhost:6380"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "apps/spotify-proxy",
     "apps/uploads",
     "apps/xata-proxy",
-    "packages/*",
     "crates"
   ]
 }


### PR DESCRIPTION
* Fix for this bun install command:

<img width="476" height="121" alt="Screenshot 2025-10-04 at 14 26 38" src="https://github.com/user-attachments/assets/91419cc0-b544-430d-a831-39360038f522" />
se)

* Fix postgres_url typo in .env.example