### PR TITLE
Add endpoint for personalized track recommendations

### DIFF
--- a/apps/api/lexicons/feed/defs.json
+++ b/apps/api/lexicons/feed/defs.json
@@ -234,6 +234,104 @@
           "type": "string"
         }
       }
+    },
+    "recommendedArtistView": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "name": {
+          "type": "string"
+        },
+        "picture": {
+          "type": "string",
+          "format": "uri"
+        },
+        "genres": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendationScore": {
+          "type": "integer"
+        },
+        "source": {
+          "type": "string",
+          "description": "neighbour | social | serendipity"
+        }
+      }
+    },
+    "recommendedArtistsView": {
+      "type": "object",
+      "properties": {
+        "artists": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "app.rocksky.feed.defs#recommendedArtistView"
+          }
+        },
+        "cursor": {
+          "type": "string"
+        }
+      }
+    },
+    "recommendedAlbumView": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "artist": {
+          "type": "string"
+        },
+        "artistUri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "year": {
+          "type": "integer"
+        },
+        "albumArt": {
+          "type": "string",
+          "format": "uri"
+        },
+        "recommendationScore": {
+          "type": "integer"
+        },
+        "source": {
+          "type": "string",
+          "description": "known-artist | new-artist | serendipity"
+        }
+      }
+    },
+    "recommendedAlbumsView": {
+      "type": "object",
+      "properties": {
+        "albums": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "app.rocksky.feed.defs#recommendedAlbumView"
+          }
+        },
+        "cursor": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/apps/api/lexicons/feed/defs.json
+++ b/apps/api/lexicons/feed/defs.json
@@ -173,6 +173,67 @@
           "description": "The pagination cursor for the next set of results."
         }
       }
+    },
+    "recommendationView": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "artist": {
+          "type": "string"
+        },
+        "album": {
+          "type": "string"
+        },
+        "albumArt": {
+          "type": "string",
+          "format": "uri"
+        },
+        "trackUri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "artistUri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "albumUri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "genres": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendationScore": {
+          "type": "integer"
+        },
+        "source": {
+          "type": "string",
+          "description": "neighbour | social | serendipity"
+        },
+        "likesCount": {
+          "type": "integer"
+        }
+      }
+    },
+    "recommendationsView": {
+      "type": "object",
+      "properties": {
+        "recommendations": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "app.rocksky.feed.defs#recommendationView"
+          }
+        },
+        "cursor": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/apps/api/lexicons/feed/getAlbumRecommendations.json
+++ b/apps/api/lexicons/feed/getAlbumRecommendations.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "app.rocksky.feed.getAlbumRecommendations",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get personalised album recommendations for a user",
+      "parameters": {
+        "type": "params",
+        "required": [
+          "did"
+        ],
+        "properties": {
+          "did": {
+            "type": "string",
+            "description": "DID or handle of the user to recommend for."
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "app.rocksky.feed.defs#recommendedAlbumsView"
+        }
+      }
+    }
+  }
+}

--- a/apps/api/lexicons/feed/getArtistRecommendations.json
+++ b/apps/api/lexicons/feed/getArtistRecommendations.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "app.rocksky.feed.getArtistRecommendations",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get personalised artist recommendations for a user",
+      "parameters": {
+        "type": "params",
+        "required": [
+          "did"
+        ],
+        "properties": {
+          "did": {
+            "type": "string",
+            "description": "DID or handle of the user to recommend for."
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "app.rocksky.feed.defs#recommendedArtistsView"
+        }
+      }
+    }
+  }
+}

--- a/apps/api/lexicons/feed/getRecommendations.json
+++ b/apps/api/lexicons/feed/getRecommendations.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "app.rocksky.feed.getRecommendations",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get personalised track recommendations for a user",
+      "parameters": {
+        "type": "params",
+        "required": [
+          "did"
+        ],
+        "properties": {
+          "did": {
+            "type": "string",
+            "description": "DID or handle of the user to recommend for."
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "app.rocksky.feed.defs#recommendationsView"
+        }
+      }
+    }
+  }
+}

--- a/apps/api/pkl/defs/feed/defs.pkl
+++ b/apps/api/pkl/defs/feed/defs.pkl
@@ -240,4 +240,106 @@ defs = new Mapping<String, ObjectType> {
       }
     }
   }
+
+  ["recommendedArtistView"] = new ObjectType {
+    type = "object"
+    properties {
+      ["id"] = new StringType {
+        type = "string"
+      }
+      ["uri"] = new StringType {
+        type = "string"
+        format = "at-uri"
+      }
+      ["name"] = new StringType {
+        type = "string"
+      }
+      ["picture"] = new StringType {
+        type = "string"
+        format = "uri"
+      }
+      ["genres"] = new Array {
+        type = "array"
+        items = new StringType {
+          type = "string"
+        }
+      }
+      ["recommendationScore"] = new IntegerType {
+        type = "integer"
+      }
+      ["source"] = new StringType {
+        type = "string"
+        description = "neighbour | social | serendipity"
+      }
+    }
+  }
+
+  ["recommendedArtistsView"] = new ObjectType {
+    type = "object"
+    properties {
+      ["artists"] = new Array {
+        type = "array"
+        items = new Ref {
+          type = "ref"
+          ref = "app.rocksky.feed.defs#recommendedArtistView"
+        }
+      }
+      ["cursor"] = new StringType {
+        type = "string"
+      }
+    }
+  }
+
+  ["recommendedAlbumView"] = new ObjectType {
+    type = "object"
+    properties {
+      ["id"] = new StringType {
+        type = "string"
+      }
+      ["uri"] = new StringType {
+        type = "string"
+        format = "at-uri"
+      }
+      ["title"] = new StringType {
+        type = "string"
+      }
+      ["artist"] = new StringType {
+        type = "string"
+      }
+      ["artistUri"] = new StringType {
+        type = "string"
+        format = "at-uri"
+      }
+      ["year"] = new IntegerType {
+        type = "integer"
+      }
+      ["albumArt"] = new StringType {
+        type = "string"
+        format = "uri"
+      }
+      ["recommendationScore"] = new IntegerType {
+        type = "integer"
+      }
+      ["source"] = new StringType {
+        type = "string"
+        description = "known-artist | new-artist | serendipity"
+      }
+    }
+  }
+
+  ["recommendedAlbumsView"] = new ObjectType {
+    type = "object"
+    properties {
+      ["albums"] = new Array {
+        type = "array"
+        items = new Ref {
+          type = "ref"
+          ref = "app.rocksky.feed.defs#recommendedAlbumView"
+        }
+      }
+      ["cursor"] = new StringType {
+        type = "string"
+      }
+    }
+  }
 }

--- a/apps/api/pkl/defs/feed/defs.pkl
+++ b/apps/api/pkl/defs/feed/defs.pkl
@@ -177,4 +177,67 @@ defs = new Mapping<String, ObjectType> {
       }
     }
   }
+
+  ["recommendationView"] = new ObjectType {
+    type = "object"
+    properties {
+      ["title"] = new StringType {
+        type = "string"
+      }
+      ["artist"] = new StringType {
+        type = "string"
+      }
+      ["album"] = new StringType {
+        type = "string"
+      }
+      ["albumArt"] = new StringType {
+        type = "string"
+        format = "uri"
+      }
+      ["trackUri"] = new StringType {
+        type = "string"
+        format = "at-uri"
+      }
+      ["artistUri"] = new StringType {
+        type = "string"
+        format = "at-uri"
+      }
+      ["albumUri"] = new StringType {
+        type = "string"
+        format = "at-uri"
+      }
+      ["genres"] = new Array {
+        type = "array"
+        items = new StringType {
+          type = "string"
+        }
+      }
+      ["recommendationScore"] = new IntegerType {
+        type = "integer"
+      }
+      ["source"] = new StringType {
+        type = "string"
+        description = "neighbour | social | serendipity"
+      }
+      ["likesCount"] = new IntegerType {
+        type = "integer"
+      }
+    }
+  }
+
+  ["recommendationsView"] = new ObjectType {
+    type = "object"
+    properties {
+      ["recommendations"] = new Array {
+        type = "array"
+        items = new Ref {
+          type = "ref"
+          ref = "app.rocksky.feed.defs#recommendationView"
+        }
+      }
+      ["cursor"] = new StringType {
+        type = "string"
+      }
+    }
+  }
 }

--- a/apps/api/pkl/defs/feed/getAlbumRecommendations.pkl
+++ b/apps/api/pkl/defs/feed/getAlbumRecommendations.pkl
@@ -1,0 +1,32 @@
+amends  "../../schema/lexicon.pkl"
+
+lexicon = 1
+id = "app.rocksky.feed.getAlbumRecommendations"
+defs = new Mapping<String, Query> {
+  ["main"] {
+    type = "query"
+    description = "Get personalised album recommendations for a user"
+    parameters {
+      type = "params"
+      required = List("did")
+      properties {
+        ["did"] = new StringType {
+          type = "string"
+          description = "DID or handle of the user to recommend for."
+        }
+        ["limit"] = new IntegerType {
+          type = "integer"
+          minimum = 1
+          maximum = 100
+        }
+      }
+    }
+    output {
+      encoding = "application/json"
+      schema = new Ref {
+        type = "ref"
+        ref = "app.rocksky.feed.defs#recommendedAlbumsView"
+      }
+    }
+  }
+}

--- a/apps/api/pkl/defs/feed/getArtistRecommendations.pkl
+++ b/apps/api/pkl/defs/feed/getArtistRecommendations.pkl
@@ -1,0 +1,32 @@
+amends  "../../schema/lexicon.pkl"
+
+lexicon = 1
+id = "app.rocksky.feed.getArtistRecommendations"
+defs = new Mapping<String, Query> {
+  ["main"] {
+    type = "query"
+    description = "Get personalised artist recommendations for a user"
+    parameters {
+      type = "params"
+      required = List("did")
+      properties {
+        ["did"] = new StringType {
+          type = "string"
+          description = "DID or handle of the user to recommend for."
+        }
+        ["limit"] = new IntegerType {
+          type = "integer"
+          minimum = 1
+          maximum = 100
+        }
+      }
+    }
+    output {
+      encoding = "application/json"
+      schema = new Ref {
+        type = "ref"
+        ref = "app.rocksky.feed.defs#recommendedArtistsView"
+      }
+    }
+  }
+}

--- a/apps/api/pkl/defs/feed/getRecommendations.pkl
+++ b/apps/api/pkl/defs/feed/getRecommendations.pkl
@@ -1,0 +1,32 @@
+amends  "../../schema/lexicon.pkl"
+
+lexicon = 1
+id = "app.rocksky.feed.getRecommendations"
+defs = new Mapping<String, Query> {
+  ["main"] {
+    type = "query"
+    description = "Get personalised track recommendations for a user"
+    parameters {
+      type = "params"
+      required = List("did")
+      properties {
+        ["did"] = new StringType {
+          type = "string"
+          description = "DID or handle of the user to recommend for."
+        }
+        ["limit"] = new IntegerType {
+          type = "integer"
+          minimum = 1
+          maximum = 100
+        }
+      }
+    }
+    output {
+      encoding = "application/json"
+      schema = new Ref {
+        type = "ref"
+        ref = "app.rocksky.feed.defs#recommendationsView"
+      }
+    }
+  }
+}

--- a/apps/api/src/lexicon/index.ts
+++ b/apps/api/src/lexicon/index.ts
@@ -47,6 +47,7 @@ import type * as AppRockskyFeedGetFeed from "./types/app/rocksky/feed/getFeed";
 import type * as AppRockskyFeedGetFeedGenerator from "./types/app/rocksky/feed/getFeedGenerator";
 import type * as AppRockskyFeedGetFeedGenerators from "./types/app/rocksky/feed/getFeedGenerators";
 import type * as AppRockskyFeedGetFeedSkeleton from "./types/app/rocksky/feed/getFeedSkeleton";
+import type * as AppRockskyFeedGetRecommendations from "./types/app/rocksky/feed/getRecommendations";
 import type * as AppRockskyFeedGetStories from "./types/app/rocksky/feed/getStories";
 import type * as AppRockskyFeedSearch from "./types/app/rocksky/feed/search";
 import type * as AppRockskyGoogledriveDownloadFile from "./types/app/rocksky/googledrive/downloadFile";
@@ -694,6 +695,17 @@ export class AppRockskyFeedNS {
     >,
   ) {
     const nsid = "app.rocksky.feed.getFeedSkeleton"; // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg);
+  }
+
+  getRecommendations<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppRockskyFeedGetRecommendations.Handler<ExtractAuth<AV>>,
+      AppRockskyFeedGetRecommendations.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = "app.rocksky.feed.getRecommendations"; // @ts-ignore
     return this._server.xrpc.method(nsid, cfg);
   }
 

--- a/apps/api/src/lexicon/index.ts
+++ b/apps/api/src/lexicon/index.ts
@@ -43,6 +43,8 @@ import type * as AppRockskyDropboxGetFiles from "./types/app/rocksky/dropbox/get
 import type * as AppRockskyDropboxGetMetadata from "./types/app/rocksky/dropbox/getMetadata";
 import type * as AppRockskyDropboxGetTemporaryLink from "./types/app/rocksky/dropbox/getTemporaryLink";
 import type * as AppRockskyFeedDescribeFeedGenerator from "./types/app/rocksky/feed/describeFeedGenerator";
+import type * as AppRockskyFeedGetAlbumRecommendations from "./types/app/rocksky/feed/getAlbumRecommendations";
+import type * as AppRockskyFeedGetArtistRecommendations from "./types/app/rocksky/feed/getArtistRecommendations";
 import type * as AppRockskyFeedGetFeed from "./types/app/rocksky/feed/getFeed";
 import type * as AppRockskyFeedGetFeedGenerator from "./types/app/rocksky/feed/getFeedGenerator";
 import type * as AppRockskyFeedGetFeedGenerators from "./types/app/rocksky/feed/getFeedGenerators";
@@ -651,6 +653,28 @@ export class AppRockskyFeedNS {
     >,
   ) {
     const nsid = "app.rocksky.feed.describeFeedGenerator"; // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg);
+  }
+
+  getAlbumRecommendations<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppRockskyFeedGetAlbumRecommendations.Handler<ExtractAuth<AV>>,
+      AppRockskyFeedGetAlbumRecommendations.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = "app.rocksky.feed.getAlbumRecommendations"; // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg);
+  }
+
+  getArtistRecommendations<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppRockskyFeedGetArtistRecommendations.Handler<ExtractAuth<AV>>,
+      AppRockskyFeedGetArtistRecommendations.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = "app.rocksky.feed.getArtistRecommendations"; // @ts-ignore
     return this._server.xrpc.method(nsid, cfg);
   }
 

--- a/apps/api/src/lexicon/lexicons.ts
+++ b/apps/api/src/lexicon/lexicons.ts
@@ -2759,6 +2759,104 @@ export const schemaDict = {
           },
         },
       },
+      recommendedArtistView: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+          },
+          uri: {
+            type: "string",
+            format: "at-uri",
+          },
+          name: {
+            type: "string",
+          },
+          picture: {
+            type: "string",
+            format: "uri",
+          },
+          genres: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+          recommendationScore: {
+            type: "integer",
+          },
+          source: {
+            type: "string",
+            description: "neighbour | social | serendipity",
+          },
+        },
+      },
+      recommendedArtistsView: {
+        type: "object",
+        properties: {
+          artists: {
+            type: "array",
+            items: {
+              type: "ref",
+              ref: "lex:app.rocksky.feed.defs#recommendedArtistView",
+            },
+          },
+          cursor: {
+            type: "string",
+          },
+        },
+      },
+      recommendedAlbumView: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+          },
+          uri: {
+            type: "string",
+            format: "at-uri",
+          },
+          title: {
+            type: "string",
+          },
+          artist: {
+            type: "string",
+          },
+          artistUri: {
+            type: "string",
+            format: "at-uri",
+          },
+          year: {
+            type: "integer",
+          },
+          albumArt: {
+            type: "string",
+            format: "uri",
+          },
+          recommendationScore: {
+            type: "integer",
+          },
+          source: {
+            type: "string",
+            description: "known-artist | new-artist | serendipity",
+          },
+        },
+      },
+      recommendedAlbumsView: {
+        type: "object",
+        properties: {
+          albums: {
+            type: "array",
+            items: {
+              type: "ref",
+              ref: "lex:app.rocksky.feed.defs#recommendedAlbumView",
+            },
+          },
+          cursor: {
+            type: "string",
+          },
+        },
+      },
     },
   },
   AppRockskyFeedDescribeFeedGenerator: {
@@ -2833,6 +2931,70 @@ export const schemaDict = {
               type: "string",
               format: "datetime",
             },
+          },
+        },
+      },
+    },
+  },
+  AppRockskyFeedGetAlbumRecommendations: {
+    lexicon: 1,
+    id: "app.rocksky.feed.getAlbumRecommendations",
+    defs: {
+      main: {
+        type: "query",
+        description: "Get personalised album recommendations for a user",
+        parameters: {
+          type: "params",
+          required: ["did"],
+          properties: {
+            did: {
+              type: "string",
+              description: "DID or handle of the user to recommend for.",
+            },
+            limit: {
+              type: "integer",
+              maximum: 100,
+              minimum: 1,
+            },
+          },
+        },
+        output: {
+          encoding: "application/json",
+          schema: {
+            type: "ref",
+            ref: "lex:app.rocksky.feed.defs#recommendedAlbumsView",
+          },
+        },
+      },
+    },
+  },
+  AppRockskyFeedGetArtistRecommendations: {
+    lexicon: 1,
+    id: "app.rocksky.feed.getArtistRecommendations",
+    defs: {
+      main: {
+        type: "query",
+        description: "Get personalised artist recommendations for a user",
+        parameters: {
+          type: "params",
+          required: ["did"],
+          properties: {
+            did: {
+              type: "string",
+              description: "DID or handle of the user to recommend for.",
+            },
+            limit: {
+              type: "integer",
+              maximum: 100,
+              minimum: 1,
+            },
+          },
+        },
+        output: {
+          encoding: "application/json",
+          schema: {
+            type: "ref",
+            ref: "lex:app.rocksky.feed.defs#recommendedArtistsView",
           },
         },
       },
@@ -6296,6 +6458,10 @@ export const ids = {
   AppRockskyFeedDefs: "app.rocksky.feed.defs",
   AppRockskyFeedDescribeFeedGenerator: "app.rocksky.feed.describeFeedGenerator",
   AppRockskyFeedGenerator: "app.rocksky.feed.generator",
+  AppRockskyFeedGetAlbumRecommendations:
+    "app.rocksky.feed.getAlbumRecommendations",
+  AppRockskyFeedGetArtistRecommendations:
+    "app.rocksky.feed.getArtistRecommendations",
   AppRockskyFeedGetFeed: "app.rocksky.feed.getFeed",
   AppRockskyFeedGetFeedGenerator: "app.rocksky.feed.getFeedGenerator",
   AppRockskyFeedGetFeedGenerators: "app.rocksky.feed.getFeedGenerators",

--- a/apps/api/src/lexicon/lexicons.ts
+++ b/apps/api/src/lexicon/lexicons.ts
@@ -2234,6 +2234,14 @@ export const schemaDict = {
               type: "string",
               description: "The genre to filter by",
             },
+            from: {
+              type: "string",
+              description: "Start date (ISO 8601). Defaults to 6 months ago.",
+            },
+            to: {
+              type: "string",
+              description: "End date (ISO 8601). Defaults to today.",
+            },
           },
         },
         output: {
@@ -2690,6 +2698,67 @@ export const schemaDict = {
           },
         },
       },
+      recommendationView: {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+          },
+          artist: {
+            type: "string",
+          },
+          album: {
+            type: "string",
+          },
+          albumArt: {
+            type: "string",
+            format: "uri",
+          },
+          trackUri: {
+            type: "string",
+            format: "at-uri",
+          },
+          artistUri: {
+            type: "string",
+            format: "at-uri",
+          },
+          albumUri: {
+            type: "string",
+            format: "at-uri",
+          },
+          genres: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+          recommendationScore: {
+            type: "integer",
+          },
+          source: {
+            type: "string",
+            description: "neighbour | social | serendipity",
+          },
+          likesCount: {
+            type: "integer",
+          },
+        },
+      },
+      recommendationsView: {
+        type: "object",
+        properties: {
+          recommendations: {
+            type: "array",
+            items: {
+              type: "ref",
+              ref: "lex:app.rocksky.feed.defs#recommendationView",
+            },
+          },
+          cursor: {
+            type: "string",
+          },
+        },
+      },
     },
   },
   AppRockskyFeedDescribeFeedGenerator: {
@@ -2916,6 +2985,38 @@ export const schemaDict = {
                   "The pagination cursor for the next set of results.",
               },
             },
+          },
+        },
+      },
+    },
+  },
+  AppRockskyFeedGetRecommendations: {
+    lexicon: 1,
+    id: "app.rocksky.feed.getRecommendations",
+    defs: {
+      main: {
+        type: "query",
+        description: "Get personalised track recommendations for a user",
+        parameters: {
+          type: "params",
+          required: ["did"],
+          properties: {
+            did: {
+              type: "string",
+              description: "DID or handle of the user to recommend for.",
+            },
+            limit: {
+              type: "integer",
+              maximum: 100,
+              minimum: 1,
+            },
+          },
+        },
+        output: {
+          encoding: "application/json",
+          schema: {
+            type: "ref",
+            ref: "lex:app.rocksky.feed.defs#recommendationsView",
           },
         },
       },
@@ -6199,6 +6300,7 @@ export const ids = {
   AppRockskyFeedGetFeedGenerator: "app.rocksky.feed.getFeedGenerator",
   AppRockskyFeedGetFeedGenerators: "app.rocksky.feed.getFeedGenerators",
   AppRockskyFeedGetFeedSkeleton: "app.rocksky.feed.getFeedSkeleton",
+  AppRockskyFeedGetRecommendations: "app.rocksky.feed.getRecommendations",
   AppRockskyFeedGetStories: "app.rocksky.feed.getStories",
   AppRockskyFeedSearch: "app.rocksky.feed.search",
   AppRockskyGoogledriveDefs: "app.rocksky.googledrive.defs",

--- a/apps/api/src/lexicon/types/app/rocksky/feed/defs.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/feed/defs.ts
@@ -180,3 +180,49 @@ export function isFeedView(v: unknown): v is FeedView {
 export function validateFeedView(v: unknown): ValidationResult {
   return lexicons.validate("app.rocksky.feed.defs#feedView", v);
 }
+
+export interface RecommendationView {
+  title?: string;
+  artist?: string;
+  album?: string;
+  albumArt?: string;
+  trackUri?: string;
+  artistUri?: string;
+  albumUri?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  /** neighbour | social | serendipity */
+  source?: string;
+  likesCount?: number;
+  [k: string]: unknown;
+}
+
+export function isRecommendationView(v: unknown): v is RecommendationView {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.feed.defs#recommendationView"
+  );
+}
+
+export function validateRecommendationView(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.feed.defs#recommendationView", v);
+}
+
+export interface RecommendationsView {
+  recommendations?: RecommendationView[];
+  cursor?: string;
+  [k: string]: unknown;
+}
+
+export function isRecommendationsView(v: unknown): v is RecommendationsView {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.feed.defs#recommendationsView"
+  );
+}
+
+export function validateRecommendationsView(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.feed.defs#recommendationsView", v);
+}

--- a/apps/api/src/lexicon/types/app/rocksky/feed/defs.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/feed/defs.ts
@@ -226,3 +226,95 @@ export function isRecommendationsView(v: unknown): v is RecommendationsView {
 export function validateRecommendationsView(v: unknown): ValidationResult {
   return lexicons.validate("app.rocksky.feed.defs#recommendationsView", v);
 }
+
+export interface RecommendedArtistView {
+  id?: string;
+  uri?: string;
+  name?: string;
+  picture?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  /** neighbour | social | serendipity */
+  source?: string;
+  [k: string]: unknown;
+}
+
+export function isRecommendedArtistView(
+  v: unknown,
+): v is RecommendedArtistView {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.feed.defs#recommendedArtistView"
+  );
+}
+
+export function validateRecommendedArtistView(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.feed.defs#recommendedArtistView", v);
+}
+
+export interface RecommendedArtistsView {
+  artists?: RecommendedArtistView[];
+  cursor?: string;
+  [k: string]: unknown;
+}
+
+export function isRecommendedArtistsView(
+  v: unknown,
+): v is RecommendedArtistsView {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.feed.defs#recommendedArtistsView"
+  );
+}
+
+export function validateRecommendedArtistsView(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.feed.defs#recommendedArtistsView", v);
+}
+
+export interface RecommendedAlbumView {
+  id?: string;
+  uri?: string;
+  title?: string;
+  artist?: string;
+  artistUri?: string;
+  year?: number;
+  albumArt?: string;
+  recommendationScore?: number;
+  /** known-artist | new-artist | serendipity */
+  source?: string;
+  [k: string]: unknown;
+}
+
+export function isRecommendedAlbumView(v: unknown): v is RecommendedAlbumView {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.feed.defs#recommendedAlbumView"
+  );
+}
+
+export function validateRecommendedAlbumView(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.feed.defs#recommendedAlbumView", v);
+}
+
+export interface RecommendedAlbumsView {
+  albums?: RecommendedAlbumView[];
+  cursor?: string;
+  [k: string]: unknown;
+}
+
+export function isRecommendedAlbumsView(
+  v: unknown,
+): v is RecommendedAlbumsView {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.feed.defs#recommendedAlbumsView"
+  );
+}
+
+export function validateRecommendedAlbumsView(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.feed.defs#recommendedAlbumsView", v);
+}

--- a/apps/api/src/lexicon/types/app/rocksky/feed/getAlbumRecommendations.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/feed/getAlbumRecommendations.ts
@@ -1,0 +1,44 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import type express from "express";
+import { ValidationResult, BlobRef } from "@atproto/lexicon";
+import { lexicons } from "../../../../lexicons";
+import { isObj, hasProp } from "../../../../util";
+import { CID } from "multiformats/cid";
+import type { HandlerAuth, HandlerPipeThrough } from "@atproto/xrpc-server";
+import type * as AppRockskyFeedDefs from "./defs";
+
+export interface QueryParams {
+  /** DID or handle of the user to recommend for. */
+  did: string;
+  limit?: number;
+}
+
+export type InputSchema = undefined;
+export type OutputSchema = AppRockskyFeedDefs.RecommendedAlbumsView;
+export type HandlerInput = undefined;
+
+export interface HandlerSuccess {
+  encoding: "application/json";
+  body: OutputSchema;
+  headers?: { [key: string]: string };
+}
+
+export interface HandlerError {
+  status: number;
+  message?: string;
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough;
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA;
+  params: QueryParams;
+  input: HandlerInput;
+  req: express.Request;
+  res: express.Response;
+  resetRouteRateLimits: () => Promise<void>;
+};
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput;

--- a/apps/api/src/lexicon/types/app/rocksky/feed/getArtistRecommendations.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/feed/getArtistRecommendations.ts
@@ -1,0 +1,44 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import type express from "express";
+import { ValidationResult, BlobRef } from "@atproto/lexicon";
+import { lexicons } from "../../../../lexicons";
+import { isObj, hasProp } from "../../../../util";
+import { CID } from "multiformats/cid";
+import type { HandlerAuth, HandlerPipeThrough } from "@atproto/xrpc-server";
+import type * as AppRockskyFeedDefs from "./defs";
+
+export interface QueryParams {
+  /** DID or handle of the user to recommend for. */
+  did: string;
+  limit?: number;
+}
+
+export type InputSchema = undefined;
+export type OutputSchema = AppRockskyFeedDefs.RecommendedArtistsView;
+export type HandlerInput = undefined;
+
+export interface HandlerSuccess {
+  encoding: "application/json";
+  body: OutputSchema;
+  headers?: { [key: string]: string };
+}
+
+export interface HandlerError {
+  status: number;
+  message?: string;
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough;
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA;
+  params: QueryParams;
+  input: HandlerInput;
+  req: express.Request;
+  res: express.Response;
+  resetRouteRateLimits: () => Promise<void>;
+};
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput;

--- a/apps/api/src/lexicon/types/app/rocksky/feed/getRecommendations.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/feed/getRecommendations.ts
@@ -1,0 +1,44 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import type express from "express";
+import { ValidationResult, BlobRef } from "@atproto/lexicon";
+import { lexicons } from "../../../../lexicons";
+import { isObj, hasProp } from "../../../../util";
+import { CID } from "multiformats/cid";
+import type { HandlerAuth, HandlerPipeThrough } from "@atproto/xrpc-server";
+import type * as AppRockskyFeedDefs from "./defs";
+
+export interface QueryParams {
+  /** DID or handle of the user to recommend for. */
+  did: string;
+  limit?: number;
+}
+
+export type InputSchema = undefined;
+export type OutputSchema = AppRockskyFeedDefs.RecommendationsView;
+export type HandlerInput = undefined;
+
+export interface HandlerSuccess {
+  encoding: "application/json";
+  body: OutputSchema;
+  headers?: { [key: string]: string };
+}
+
+export interface HandlerError {
+  status: number;
+  message?: string;
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough;
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA;
+  params: QueryParams;
+  input: HandlerInput;
+  req: express.Request;
+  res: express.Response;
+  resetRouteRateLimits: () => Promise<void>;
+};
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput;

--- a/apps/api/src/xrpc/app/rocksky/feed/getAlbumRecommendations.ts
+++ b/apps/api/src/xrpc/app/rocksky/feed/getAlbumRecommendations.ts
@@ -1,0 +1,382 @@
+import type { Context } from "context";
+import { consola } from "consola";
+import { and, desc, eq, inArray, ne, notInArray, or, sql } from "drizzle-orm";
+import { Cache, Duration, Effect, pipe } from "effect";
+import type { Server } from "lexicon";
+import type {
+  RecommendedAlbumView,
+  RecommendedAlbumsView,
+} from "lexicon/types/app/rocksky/feed/defs";
+import type { QueryParams } from "lexicon/types/app/rocksky/feed/getAlbumRecommendations";
+import tables from "schema";
+
+const DECAY_LAMBDA = 0.02 as const;
+const NEIGHBOUR_LIMIT = 20;
+const RESULT_LIMIT = 50;
+
+export default function (server: Server, ctx: Context) {
+  const cache = Cache.make({
+    capacity: 200,
+    timeToLive: Duration.minutes(5),
+    lookup: (params: QueryParams) =>
+      pipe(
+        { params, ctx },
+        retrieve,
+        Effect.flatMap(hydrate),
+        Effect.flatMap(presentation),
+        Effect.retry({ times: 3 }),
+        Effect.timeout("30 seconds"),
+      ),
+  });
+
+  const getAlbumRecommendations = (params: QueryParams) =>
+    pipe(
+      cache,
+      Effect.flatMap((c) => c.get(params)),
+      Effect.catchAll((err) => {
+        consola.error("getAlbumRecommendations error:", err);
+        return Effect.succeed({ albums: [] });
+      }),
+    );
+
+  server.app.rocksky.feed.getAlbumRecommendations({
+    handler: async ({ params }) => {
+      const result = await Effect.runPromise(getAlbumRecommendations(params));
+      return { encoding: "application/json", body: result };
+    },
+  });
+}
+
+const retrieve = ({
+  params,
+  ctx,
+}: {
+  params: QueryParams;
+  ctx: Context;
+}): Effect.Effect<RetrieveResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const user = await ctx.db
+        .select({ id: tables.users.id })
+        .from(tables.users)
+        .where(
+          or(
+            eq(tables.users.did, params.did),
+            eq(tables.users.handle, params.did),
+          ),
+        )
+        .then((rows) => rows[0]);
+
+      if (!user) throw new Error("User not found");
+
+      const limit = Math.min(params.limit ?? RESULT_LIMIT, 100);
+
+      // Albums the user has already heard
+      const heardAlbumRows = await ctx.db
+        .select({ albumId: tables.scrobbles.albumId })
+        .from(tables.scrobbles)
+        .where(eq(tables.scrobbles.userId, user.id))
+        .groupBy(tables.scrobbles.albumId);
+
+      const heardAlbumIds = heardAlbumRows
+        .map((r) => r.albumId)
+        .filter((id): id is string => id !== null);
+
+      // Artists the user knows, with their scrobble counts as familiarity score
+      const userArtistRows = await ctx.db
+        .select({
+          artistId: tables.userArtists.artistId,
+          scrobbles: tables.userArtists.scrobbles,
+        })
+        .from(tables.userArtists)
+        .where(eq(tables.userArtists.userId, user.id))
+        .orderBy(desc(tables.userArtists.scrobbles))
+        .limit(100);
+
+      const heardArtistIds = userArtistRows.map((r) => r.artistId);
+      const artistFamiliarityMap = new Map(
+        userArtistRows.map((r) => [r.artistId, r.scrobbles ?? 0]),
+      );
+
+      // Pool A — albums from known artists not yet heard
+      // Resolve artist IDs → URIs to join against albums.artistUri
+      const knownArtistUris =
+        heardArtistIds.length > 0
+          ? await ctx.db
+              .select({ uri: tables.artists.uri })
+              .from(tables.artists)
+              .where(inArray(tables.artists.id, heardArtistIds))
+              .then((rows) =>
+                rows.map((r) => r.uri).filter((u): u is string => u !== null),
+              )
+          : [];
+
+      const poolA: Candidate[] =
+        knownArtistUris.length > 0
+          ? await ctx.db
+              .select({
+                id: tables.albums.id,
+                artistUri: tables.albums.artistUri,
+              })
+              .from(tables.albums)
+              .where(
+                and(
+                  inArray(tables.albums.artistUri, knownArtistUris),
+                  heardAlbumIds.length > 0
+                    ? notInArray(tables.albums.id, heardAlbumIds)
+                    : undefined,
+                ),
+              )
+              .limit(200)
+              .then((rows) =>
+                rows.flatMap((row): Candidate[] => {
+                  if (!row.artistUri) return [];
+                  const artistId = userArtistRows.find(
+                    (a) =>
+                      knownArtistUris[heardArtistIds.indexOf(a.artistId)] ===
+                      row.artistUri,
+                  )?.artistId;
+                  const score = artistId
+                    ? (artistFamiliarityMap.get(artistId) ?? 1)
+                    : 1;
+                  return [
+                    {
+                      albumId: row.id,
+                      score: Number(score),
+                      source: "known-artist",
+                    },
+                  ];
+                }),
+              )
+          : [];
+
+      // Pool B — albums from artists neighbours love but user hasn't heard
+      const neighbours =
+        heardArtistIds.length > 0
+          ? await ctx.db
+              .select({
+                userId: tables.scrobbles.userId,
+                sharedCount: sql<number>`count(distinct ${tables.scrobbles.artistId})`,
+              })
+              .from(tables.scrobbles)
+              .where(
+                and(
+                  inArray(tables.scrobbles.artistId, heardArtistIds),
+                  ne(tables.scrobbles.userId, user.id),
+                ),
+              )
+              .groupBy(tables.scrobbles.userId)
+              .orderBy(desc(sql`count(distinct ${tables.scrobbles.artistId})`))
+              .limit(NEIGHBOUR_LIMIT)
+          : [];
+
+      const neighbourIds = neighbours
+        .map((n) => n.userId)
+        .filter((id): id is string => id !== null);
+
+      const similarityMap = new Map(
+        neighbours.map((n) => [
+          n.userId!,
+          heardArtistIds.length > 0
+            ? Number(n.sharedCount) / heardArtistIds.length
+            : 0,
+        ]),
+      );
+
+      const poolBAlreadyInA = new Set(poolA.map((c) => c.albumId));
+
+      const poolB: Candidate[] =
+        neighbourIds.length > 0
+          ? await (async () => {
+              // Neighbour artists the user hasn't heard
+              const newArtistIds = await ctx.db
+                .select({
+                  artistId: tables.scrobbles.artistId,
+                  neighbourUserId: tables.scrobbles.userId,
+                  playScore: sql<number>`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+                })
+                .from(tables.scrobbles)
+                .where(
+                  and(
+                    inArray(tables.scrobbles.userId, neighbourIds),
+                    heardArtistIds.length > 0
+                      ? notInArray(tables.scrobbles.artistId, heardArtistIds)
+                      : undefined,
+                  ),
+                )
+                .groupBy(tables.scrobbles.artistId, tables.scrobbles.userId)
+                .orderBy(
+                  desc(
+                    sql`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+                  ),
+                )
+                .limit(50);
+
+              // Score each new artist
+              const artistScoreMap = new Map<string, number>();
+              for (const row of newArtistIds) {
+                if (!row.artistId || !row.neighbourUserId) continue;
+                const similarity = similarityMap.get(row.neighbourUserId) ?? 0;
+                const score = similarity * Number(row.playScore);
+                const existing = artistScoreMap.get(row.artistId) ?? 0;
+                if (score > existing) artistScoreMap.set(row.artistId, score);
+              }
+
+              if (artistScoreMap.size === 0) return [];
+
+              const newArtistIdList = [...artistScoreMap.keys()];
+
+              // Resolve to URIs
+              const newArtistUris = await ctx.db
+                .select({ id: tables.artists.id, uri: tables.artists.uri })
+                .from(tables.artists)
+                .where(inArray(tables.artists.id, newArtistIdList))
+                .then((rows) =>
+                  rows.filter(
+                    (r): r is { id: string; uri: string } => r.uri !== null,
+                  ),
+                );
+
+              if (newArtistUris.length === 0) return [];
+
+              // Albums by those new artists
+              const albums = await ctx.db
+                .select({
+                  id: tables.albums.id,
+                  artistUri: tables.albums.artistUri,
+                })
+                .from(tables.albums)
+                .where(
+                  and(
+                    inArray(
+                      tables.albums.artistUri,
+                      newArtistUris.map((a) => a.uri),
+                    ),
+                    heardAlbumIds.length > 0
+                      ? notInArray(tables.albums.id, heardAlbumIds)
+                      : undefined,
+                  ),
+                )
+                .limit(200);
+
+              const uriToArtistId = new Map(
+                newArtistUris.map((a) => [a.uri, a.id]),
+              );
+
+              return albums
+                .filter((a) => !poolBAlreadyInA.has(a.id) && a.artistUri)
+                .map((a) => {
+                  const artistId = uriToArtistId.get(a.artistUri!);
+                  const score = artistId
+                    ? (artistScoreMap.get(artistId) ?? 0)
+                    : 0;
+                  return {
+                    albumId: a.id,
+                    score,
+                    source: "new-artist" as const,
+                  };
+                });
+            })()
+          : [];
+
+      // Merge both pools, sort by score, take top N
+      const merged = [...poolA, ...poolB].sort((a, b) => b.score - a.score);
+      const seen = new Set<string>();
+      const candidates = merged
+        .filter((c) => {
+          if (seen.has(c.albumId)) return false;
+          seen.add(c.albumId);
+          return true;
+        })
+        .slice(0, limit);
+
+      return { candidates, ctx };
+    },
+    catch: (err) => new Error(`retrieve failed: ${err}`),
+  });
+
+const hydrate = ({
+  candidates,
+  ctx,
+}: RetrieveResult): Effect.Effect<HydrateResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const albumIds = candidates
+        .map((c) => c.albumId)
+        .filter((id): id is string => id !== null);
+
+      if (albumIds.length === 0) return { items: [] };
+
+      const albumRows = await ctx.db
+        .select({
+          id: tables.albums.id,
+          uri: tables.albums.uri,
+          title: tables.albums.title,
+          artist: tables.albums.artist,
+          artistUri: tables.albums.artistUri,
+          year: tables.albums.year,
+          albumArt: tables.albums.albumArt,
+        })
+        .from(tables.albums)
+        .where(inArray(tables.albums.id, albumIds));
+
+      const albumMap = new Map(albumRows.map((a) => [a.id, a]));
+      const scoreMap = new Map(candidates.map((c) => [c.albumId, c]));
+
+      const items = albumIds
+        .map((id) => {
+          const album = albumMap.get(id);
+          const candidate = scoreMap.get(id);
+          if (!album || !candidate) return null;
+          return { ...album, score: candidate.score, source: candidate.source };
+        })
+        .filter((item): item is NonNullable<typeof item> => item !== null);
+
+      return { items };
+    },
+    catch: (err) => new Error(`hydrate failed: ${err}`),
+  });
+
+const presentation = ({
+  items,
+}: HydrateResult): Effect.Effect<RecommendedAlbumsView, never> =>
+  Effect.sync(() => ({
+    albums: items.map(
+      (item): RecommendedAlbumView => ({
+        id: item.id,
+        uri: item.uri ?? undefined,
+        title: item.title,
+        artist: item.artist,
+        artistUri: item.artistUri ?? undefined,
+        year: item.year ?? undefined,
+        albumArt: item.albumArt ?? undefined,
+        recommendationScore: item.score,
+        source: item.source,
+      }),
+    ),
+  }));
+
+type Candidate = {
+  albumId: string;
+  score: number;
+  source: "known-artist" | "new-artist" | "serendipity";
+};
+
+type RetrieveResult = {
+  candidates: Candidate[];
+  ctx: Context;
+};
+
+type HydrateResult = {
+  items: {
+    id: string;
+    uri: string | null;
+    title: string;
+    artist: string;
+    artistUri: string | null;
+    year: number | null;
+    albumArt: string | null;
+    score: number;
+    source: "known-artist" | "new-artist" | "serendipity";
+  }[];
+};

--- a/apps/api/src/xrpc/app/rocksky/feed/getArtistRecommendations.ts
+++ b/apps/api/src/xrpc/app/rocksky/feed/getArtistRecommendations.ts
@@ -1,0 +1,271 @@
+import type { Context } from "context";
+import { consola } from "consola";
+import { and, desc, eq, inArray, ne, notInArray, or, sql } from "drizzle-orm";
+import { Cache, Duration, Effect, pipe } from "effect";
+import type { Server } from "lexicon";
+import type {
+  RecommendedArtistView,
+  RecommendedArtistsView,
+} from "lexicon/types/app/rocksky/feed/defs";
+import type { QueryParams } from "lexicon/types/app/rocksky/feed/getArtistRecommendations";
+import tables from "schema";
+
+const DECAY_LAMBDA = 0.02 as const;
+const NEIGHBOUR_LIMIT = 20;
+const RESULT_LIMIT = 50;
+const SERENDIPITY_RATIO = 0.15;
+
+export default function (server: Server, ctx: Context) {
+  const cache = Cache.make({
+    capacity: 200,
+    timeToLive: Duration.minutes(5),
+    lookup: (params: QueryParams) =>
+      pipe(
+        { params, ctx },
+        retrieve,
+        Effect.flatMap(hydrate),
+        Effect.flatMap(presentation),
+        Effect.retry({ times: 3 }),
+        Effect.timeout("30 seconds"),
+      ),
+  });
+
+  const getArtistRecommendations = (params: QueryParams) =>
+    pipe(
+      cache,
+      Effect.flatMap((c) => c.get(params)),
+      Effect.catchAll((err) => {
+        consola.error("getArtistRecommendations error:", err);
+        return Effect.succeed({ artists: [] });
+      }),
+    );
+
+  server.app.rocksky.feed.getArtistRecommendations({
+    handler: async ({ params }) => {
+      const result = await Effect.runPromise(getArtistRecommendations(params));
+      return { encoding: "application/json", body: result };
+    },
+  });
+}
+
+const retrieve = ({
+  params,
+  ctx,
+}: {
+  params: QueryParams;
+  ctx: Context;
+}): Effect.Effect<RetrieveResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const user = await ctx.db
+        .select({ id: tables.users.id })
+        .from(tables.users)
+        .where(
+          or(
+            eq(tables.users.did, params.did),
+            eq(tables.users.handle, params.did),
+          ),
+        )
+        .then((rows) => rows[0]);
+
+      if (!user) throw new Error("User not found");
+
+      const limit = Math.min(params.limit ?? RESULT_LIMIT, 100);
+      const serendipityCount = Math.ceil(limit * SERENDIPITY_RATIO);
+      const mainCount = limit - serendipityCount;
+
+      // Artists the user has already heard
+      const heardRows = await ctx.db
+        .select({ artistId: tables.userArtists.artistId })
+        .from(tables.userArtists)
+        .where(eq(tables.userArtists.userId, user.id));
+
+      const heardArtistIds = heardRows.map((r) => r.artistId);
+
+      // Top neighbours by shared-artist overlap
+      const neighbours = await ctx.db
+        .select({
+          userId: tables.scrobbles.userId,
+          sharedCount: sql<number>`count(distinct ${tables.scrobbles.artistId})`,
+        })
+        .from(tables.scrobbles)
+        .where(
+          and(
+            heardArtistIds.length > 0
+              ? inArray(tables.scrobbles.artistId, heardArtistIds)
+              : undefined,
+            ne(tables.scrobbles.userId, user.id),
+          ),
+        )
+        .groupBy(tables.scrobbles.userId)
+        .orderBy(desc(sql`count(distinct ${tables.scrobbles.artistId})`))
+        .limit(NEIGHBOUR_LIMIT);
+
+      const neighbourIds = neighbours
+        .map((n) => n.userId)
+        .filter((id): id is string => id !== null);
+
+      const similarityMap = new Map(
+        neighbours.map((n) => [
+          n.userId!,
+          heardArtistIds.length > 0
+            ? Number(n.sharedCount) / heardArtistIds.length
+            : 0,
+        ]),
+      );
+
+      if (neighbourIds.length === 0) {
+        return { candidates: [], ctx };
+      }
+
+      // Artists scrobbled by neighbours but not yet heard by the user
+      const neighbourArtists = await ctx.db
+        .select({
+          artistId: tables.scrobbles.artistId,
+          neighbourUserId: tables.scrobbles.userId,
+          playScore: sql<number>`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+        })
+        .from(tables.scrobbles)
+        .where(
+          and(
+            inArray(tables.scrobbles.userId, neighbourIds),
+            heardArtistIds.length > 0
+              ? notInArray(tables.scrobbles.artistId, heardArtistIds)
+              : undefined,
+          ),
+        )
+        .groupBy(tables.scrobbles.artistId, tables.scrobbles.userId)
+        .orderBy(
+          desc(
+            sql`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+          ),
+        )
+        .limit(200);
+
+      // Score = similarity × decayed_play_count
+      const scoreMap = new Map<string, number>();
+
+      for (const row of neighbourArtists) {
+        if (!row.artistId || !row.neighbourUserId) continue;
+        const similarity = similarityMap.get(row.neighbourUserId) ?? 0;
+        const score = similarity * Number(row.playScore);
+        const existing = scoreMap.get(row.artistId) ?? 0;
+        if (score > existing) {
+          scoreMap.set(row.artistId, score);
+        }
+      }
+
+      const alreadyReturned = new Set<string>();
+
+      const mainCandidates = [...scoreMap.entries()]
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, mainCount)
+        .map(([artistId, score]) => {
+          alreadyReturned.add(artistId);
+          return { artistId, score, source: "neighbour" as const };
+        });
+
+      // Serendipity: lower-scored candidates from the tail of the scored pool
+      // — real discoveries from more distant neighbours
+      const serendipityCandidates = [...scoreMap.entries()]
+        .sort(([, a], [, b]) => b - a)
+        .slice(mainCount, mainCount + serendipityCount * 3)
+        .filter(([id]) => !alreadyReturned.has(id))
+        .slice(0, serendipityCount)
+        .map(([artistId, score]) => ({
+          artistId,
+          score,
+          source: "serendipity" as const,
+        }));
+
+      return {
+        candidates: [...mainCandidates, ...serendipityCandidates],
+        ctx,
+      };
+    },
+    catch: (err) => new Error(`retrieve failed: ${err}`),
+  });
+
+const hydrate = ({
+  candidates,
+  ctx,
+}: RetrieveResult): Effect.Effect<HydrateResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const artistIds = candidates
+        .map((c) => c.artistId)
+        .filter((id): id is string => id !== null);
+
+      if (artistIds.length === 0) return { items: [] };
+
+      const artistRows = await ctx.db
+        .select({
+          id: tables.artists.id,
+          uri: tables.artists.uri,
+          name: tables.artists.name,
+          picture: tables.artists.picture,
+          genres: tables.artists.genres,
+        })
+        .from(tables.artists)
+        .where(inArray(tables.artists.id, artistIds));
+
+      const artistMap = new Map(artistRows.map((a) => [a.id, a]));
+      const scoreMap = new Map(candidates.map((c) => [c.artistId, c]));
+
+      const items = artistIds
+        .map((id) => {
+          const artist = artistMap.get(id);
+          const candidate = scoreMap.get(id);
+          if (!artist || !candidate) return null;
+          return {
+            ...artist,
+            score: candidate.score,
+            source: candidate.source,
+          };
+        })
+        .filter((item): item is NonNullable<typeof item> => item !== null);
+
+      return { items };
+    },
+    catch: (err) => new Error(`hydrate failed: ${err}`),
+  });
+
+const presentation = ({
+  items,
+}: HydrateResult): Effect.Effect<RecommendedArtistsView, never> =>
+  Effect.sync(() => ({
+    artists: items.map(
+      (item): RecommendedArtistView => ({
+        id: item.id,
+        uri: item.uri ?? undefined,
+        name: item.name,
+        picture: item.picture ?? undefined,
+        genres: item.genres ?? [],
+        recommendationScore: item.score,
+        source: item.source,
+      }),
+    ),
+  }));
+
+type Candidate = {
+  artistId: string;
+  score: number;
+  source: "neighbour" | "serendipity";
+};
+
+type RetrieveResult = {
+  candidates: Candidate[];
+  ctx: Context;
+};
+
+type HydrateResult = {
+  items: {
+    id: string;
+    uri: string | null;
+    name: string;
+    picture: string | null;
+    genres: string[] | null;
+    score: number;
+    source: "neighbour" | "serendipity";
+  }[];
+};

--- a/apps/api/src/xrpc/app/rocksky/feed/getRecommendations.ts
+++ b/apps/api/src/xrpc/app/rocksky/feed/getRecommendations.ts
@@ -1,0 +1,412 @@
+import type { Context } from "context";
+import { consola } from "consola";
+import { and, desc, eq, inArray, ne, notInArray, or, sql } from "drizzle-orm";
+import { Cache, Duration, Effect, pipe } from "effect";
+import type { Server } from "lexicon";
+import type {
+  RecommendationView,
+  RecommendationsView,
+} from "lexicon/types/app/rocksky/feed/defs";
+import type { QueryParams } from "lexicon/types/app/rocksky/feed/getRecommendations";
+import tables from "schema";
+
+const DECAY_LAMBDA = 0.02 as const;
+const NEIGHBOUR_LIMIT = 20;
+const RESULT_LIMIT = 50;
+const SERENDIPITY_RATIO = 0.15;
+
+export default function (server: Server, ctx: Context) {
+  const cache = Cache.make({
+    capacity: 200,
+    timeToLive: Duration.minutes(5),
+    lookup: (params: QueryParams) =>
+      pipe(
+        { params, ctx },
+        retrieve,
+        Effect.flatMap(hydrate),
+        Effect.flatMap(presentation),
+        Effect.retry({ times: 3 }),
+        Effect.timeout("30 seconds"),
+      ),
+  });
+
+  const getRecommendations = (params: QueryParams) =>
+    pipe(
+      cache,
+      Effect.flatMap((c) => c.get(params)),
+      Effect.catchAll((err) => {
+        consola.error("getRecommendations error:", err);
+        return Effect.succeed({ recommendations: [] });
+      }),
+    );
+
+  server.app.rocksky.feed.getRecommendations({
+    handler: async ({ params }) => {
+      const result = await Effect.runPromise(getRecommendations(params));
+      return { encoding: "application/json", body: result };
+    },
+  });
+}
+
+const retrieve = ({
+  params,
+  ctx,
+}: {
+  params: QueryParams;
+  ctx: Context;
+}): Effect.Effect<RetrieveResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const user = await ctx.db
+        .select({ id: tables.users.id })
+        .from(tables.users)
+        .where(
+          or(
+            eq(tables.users.did, params.did),
+            eq(tables.users.handle, params.did),
+          ),
+        )
+        .then((rows) => rows[0]);
+
+      if (!user) throw new Error("User not found");
+
+      const limit = Math.min(params.limit ?? RESULT_LIMIT, 100);
+      const serendipityCount = Math.ceil(limit * SERENDIPITY_RATIO);
+      const mainCount = limit - serendipityCount;
+
+      // Tracks the user has already heard — excluded from all candidate pools
+      const heardRows = await ctx.db
+        .select({ trackId: tables.scrobbles.trackId })
+        .from(tables.scrobbles)
+        .where(eq(tables.scrobbles.userId, user.id))
+        .groupBy(tables.scrobbles.trackId);
+
+      const heardIds = heardRows
+        .map((r) => r.trackId)
+        .filter((id): id is string => id !== null);
+
+      // User's artist profile with recency decay
+      const artistProfile = await ctx.db
+        .select({
+          artistId: tables.scrobbles.artistId,
+        })
+        .from(tables.scrobbles)
+        .where(eq(tables.scrobbles.userId, user.id))
+        .groupBy(tables.scrobbles.artistId)
+        .orderBy(
+          desc(
+            sql<number>`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+          ),
+        )
+        .limit(100);
+
+      const artistIds = artistProfile
+        .map((r) => r.artistId)
+        .filter((id): id is string => id !== null);
+
+      if (artistIds.length === 0) {
+        return { candidates: [], serendipityCount, ctx };
+      }
+
+      // Top neighbours by shared-artist overlap
+      const neighbours = await ctx.db
+        .select({
+          userId: tables.scrobbles.userId,
+          sharedCount: sql<number>`count(distinct ${tables.scrobbles.artistId})`,
+        })
+        .from(tables.scrobbles)
+        .where(
+          and(
+            inArray(tables.scrobbles.artistId, artistIds),
+            ne(tables.scrobbles.userId, user.id),
+          ),
+        )
+        .groupBy(tables.scrobbles.userId)
+        .orderBy(desc(sql`count(distinct ${tables.scrobbles.artistId})`))
+        .limit(NEIGHBOUR_LIMIT);
+
+      const neighbourIds = neighbours
+        .map((n) => n.userId)
+        .filter((id): id is string => id !== null);
+
+      // similarity ∈ [0,1]: shared artists as fraction of the user's total artist count
+      const similarityMap = new Map(
+        neighbours.map((n) => [
+          n.userId!,
+          Number(n.sharedCount) / artistIds.length,
+        ]),
+      );
+
+      if (neighbourIds.length === 0) {
+        return { candidates: [], serendipityCount, ctx };
+      }
+
+      // Tracks loved by neighbours — explicit 5× signal
+      const lovedByNeighbours = await ctx.db
+        .select({
+          trackId: tables.lovedTracks.trackId,
+          userId: tables.lovedTracks.userId,
+        })
+        .from(tables.lovedTracks)
+        .where(
+          and(
+            inArray(tables.lovedTracks.userId, neighbourIds),
+            heardIds.length > 0
+              ? notInArray(tables.lovedTracks.trackId, heardIds)
+              : undefined,
+          ),
+        );
+
+      const lovedKey = (userId: string, trackId: string) =>
+        `${userId}:${trackId}`;
+      const lovedSet = new Set(
+        lovedByNeighbours.map((l) => lovedKey(l.userId, l.trackId)),
+      );
+
+      // Candidate tracks from neighbour scrobbles, decay-weighted
+      const neighbourTracks = await ctx.db
+        .select({
+          trackId: tables.scrobbles.trackId,
+          neighbourUserId: tables.scrobbles.userId,
+          playScore: sql<number>`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+        })
+        .from(tables.scrobbles)
+        .where(
+          and(
+            inArray(tables.scrobbles.userId, neighbourIds),
+            heardIds.length > 0
+              ? notInArray(tables.scrobbles.trackId, heardIds)
+              : undefined,
+          ),
+        )
+        .groupBy(tables.scrobbles.trackId, tables.scrobbles.userId)
+        .orderBy(
+          desc(
+            sql`sum(exp(-${DECAY_LAMBDA} * extract(epoch from (now() - ${tables.scrobbles.timestamp})) / 86400))`,
+          ),
+        )
+        .limit(200);
+
+      // Score = similarity × decayed_play_count × loved_boost
+      const scoreMap = new Map<string, number>();
+      const sourceMap = new Map<string, "neighbour" | "social">();
+
+      for (const row of neighbourTracks) {
+        if (!row.trackId || !row.neighbourUserId) continue;
+        const similarity = similarityMap.get(row.neighbourUserId) ?? 0;
+        const isLoved = lovedSet.has(
+          lovedKey(row.neighbourUserId, row.trackId),
+        );
+        const score = similarity * Number(row.playScore) * (isLoved ? 5 : 1);
+        const existing = scoreMap.get(row.trackId) ?? 0;
+        if (score > existing) {
+          scoreMap.set(row.trackId, score);
+          sourceMap.set(row.trackId, isLoved ? "social" : "neighbour");
+        }
+      }
+
+      // Also include loved-but-not-scrobbled tracks from neighbours
+      for (const l of lovedByNeighbours) {
+        if (scoreMap.has(l.trackId)) continue;
+        const similarity = similarityMap.get(l.userId) ?? 0;
+        scoreMap.set(l.trackId, similarity * 5);
+        sourceMap.set(l.trackId, "social");
+      }
+
+      const mainCandidates = [...scoreMap.entries()]
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, mainCount)
+        .map(([trackId, score]) => ({
+          trackId,
+          score,
+          source: sourceMap.get(trackId) ?? ("neighbour" as const),
+        }));
+
+      // Serendipity pool: tracks from artists the user hasn't heard,
+      // discovered through neighbour artists (1-hop expansion from user's taste)
+      const serendipityArtistIds = await ctx.db
+        .select({ artistId: tables.scrobbles.artistId })
+        .from(tables.scrobbles)
+        .where(
+          and(
+            inArray(tables.scrobbles.userId, neighbourIds),
+            notInArray(tables.scrobbles.artistId, artistIds),
+          ),
+        )
+        .groupBy(tables.scrobbles.artistId)
+        .orderBy(desc(sql`count(*)`))
+        .limit(50)
+        .then((rows) =>
+          rows.map((r) => r.artistId).filter((id): id is string => id !== null),
+        );
+
+      const alreadyReturned = new Set(mainCandidates.map((c) => c.trackId));
+
+      // Resolve artist IDs → artist URIs to join against tracks.artistUri
+      const serendipityArtistUris =
+        serendipityArtistIds.length > 0
+          ? await ctx.db
+              .select({ uri: tables.artists.uri })
+              .from(tables.artists)
+              .where(inArray(tables.artists.id, serendipityArtistIds))
+              .then((rows) =>
+                rows.map((r) => r.uri).filter((u): u is string => u !== null),
+              )
+          : [];
+
+      const serendipityTracks =
+        serendipityArtistUris.length > 0
+          ? await ctx.db
+              .select({ id: tables.tracks.id })
+              .from(tables.tracks)
+              .where(
+                and(
+                  inArray(tables.tracks.artistUri, serendipityArtistUris),
+                  heardIds.length > 0
+                    ? notInArray(tables.tracks.id, heardIds)
+                    : undefined,
+                ),
+              )
+              .orderBy(sql`random()`)
+              .limit(serendipityCount * 3)
+              .then((rows) =>
+                rows
+                  .filter((r) => !alreadyReturned.has(r.id))
+                  .slice(0, serendipityCount)
+                  .map((r) => ({
+                    trackId: r.id,
+                    score: 0,
+                    source: "serendipity" as const,
+                  })),
+              )
+          : [];
+
+      return {
+        candidates: [...mainCandidates, ...serendipityTracks],
+        serendipityCount,
+        ctx,
+      };
+    },
+    catch: (err) => new Error(`retrieve failed: ${err}`),
+  });
+
+const hydrate = ({
+  candidates,
+  ctx,
+}: RetrieveResult): Effect.Effect<HydrateResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const trackIds = candidates
+        .map((c) => c.trackId)
+        .filter((id): id is string => id !== null);
+
+      if (trackIds.length === 0) return { items: [] };
+
+      const [trackRows, likeRows] = await Promise.all([
+        ctx.db
+          .select({
+            id: tables.tracks.id,
+            title: tables.tracks.title,
+            artist: tables.tracks.artist,
+            album: tables.tracks.album,
+            albumArt: tables.tracks.albumArt,
+            trackUri: tables.tracks.uri,
+            artistUri: tables.artists.uri,
+            albumUri: tables.albums.uri,
+            genres: tables.artists.genres,
+          })
+          .from(tables.tracks)
+          .leftJoin(
+            tables.artists,
+            eq(tables.tracks.artistUri, tables.artists.uri),
+          )
+          .leftJoin(
+            tables.albums,
+            eq(tables.tracks.albumUri, tables.albums.uri),
+          )
+          .where(inArray(tables.tracks.id, trackIds)),
+        ctx.db
+          .select({
+            trackId: tables.lovedTracks.trackId,
+            count: sql<number>`count(*)`,
+          })
+          .from(tables.lovedTracks)
+          .where(inArray(tables.lovedTracks.trackId, trackIds))
+          .groupBy(tables.lovedTracks.trackId),
+      ]);
+
+      const trackMap = new Map(trackRows.map((r) => [r.id, r]));
+      const likeMap = new Map(
+        likeRows.map((r) => [r.trackId, Number(r.count)]),
+      );
+
+      const scoreMap = new Map(candidates.map((c) => [c.trackId, c]));
+
+      const items = trackIds
+        .map((id) => {
+          const track = trackMap.get(id);
+          const candidate = scoreMap.get(id);
+          if (!track || !candidate) return null;
+          return {
+            ...track,
+            score: candidate.score,
+            source: candidate.source,
+            likesCount: likeMap.get(id) ?? 0,
+          };
+        })
+        .filter((item): item is NonNullable<typeof item> => item !== null);
+
+      return { items };
+    },
+    catch: (err) => new Error(`hydrate failed: ${err}`),
+  });
+
+const presentation = ({
+  items,
+}: HydrateResult): Effect.Effect<RecommendationsView, never> =>
+  Effect.sync(() => ({
+    recommendations: items.map(
+      (item): RecommendationView => ({
+        title: item.title ?? undefined,
+        artist: item.artist ?? undefined,
+        album: item.album ?? undefined,
+        albumArt: item.albumArt ?? undefined,
+        trackUri: item.trackUri ?? undefined,
+        artistUri: item.artistUri ?? undefined,
+        albumUri: item.albumUri ?? undefined,
+        genres: item.genres ?? [],
+        recommendationScore: item.score,
+        source: item.source,
+        likesCount: item.likesCount,
+      }),
+    ),
+  }));
+
+type Candidate = {
+  trackId: string;
+  score: number;
+  source: "neighbour" | "social" | "serendipity";
+};
+
+type RetrieveResult = {
+  candidates: Candidate[];
+  serendipityCount: number;
+  ctx: Context;
+};
+
+type HydrateResult = {
+  items: {
+    id: string;
+    title: string | null;
+    artist: string | null;
+    album: string | null;
+    albumArt: string | null;
+    trackUri: string | null;
+    artistUri: string | null;
+    albumUri: string | null;
+    genres: string[] | null;
+    score: number;
+    source: "neighbour" | "social" | "serendipity";
+    likesCount: number;
+  }[];
+};

--- a/apps/api/src/xrpc/index.ts
+++ b/apps/api/src/xrpc/index.ts
@@ -85,6 +85,7 @@ import matchSong from "./app/rocksky/song/matchSong";
 import getTopArtists from "./app/rocksky/charts/getTopArtists";
 import getTopTracks from "./app/rocksky/charts/getTopTracks";
 import getStories from "./app/rocksky/feed/getStories";
+import getRecommendations from "./app/rocksky/feed/getRecommendations";
 
 export default function (server: Server, ctx: Context) {
   // app.rocksky
@@ -173,6 +174,7 @@ export default function (server: Server, ctx: Context) {
   getTopArtists(server, ctx);
   getTopTracks(server, ctx);
   getStories(server, ctx);
+  getRecommendations(server, ctx);
 
   return server;
 }

--- a/apps/api/src/xrpc/index.ts
+++ b/apps/api/src/xrpc/index.ts
@@ -86,6 +86,8 @@ import getTopArtists from "./app/rocksky/charts/getTopArtists";
 import getTopTracks from "./app/rocksky/charts/getTopTracks";
 import getStories from "./app/rocksky/feed/getStories";
 import getRecommendations from "./app/rocksky/feed/getRecommendations";
+import getArtistRecommendations from "./app/rocksky/feed/getArtistRecommendations";
+import getAlbumRecommendations from "./app/rocksky/feed/getAlbumRecommendations";
 
 export default function (server: Server, ctx: Context) {
   // app.rocksky
@@ -175,6 +177,8 @@ export default function (server: Server, ctx: Context) {
   getTopTracks(server, ctx);
   getStories(server, ctx);
   getRecommendations(server, ctx);
+  getArtistRecommendations(server, ctx);
+  getAlbumRecommendations(server, ctx);
 
   return server;
 }

--- a/apps/app/src/Navigation.tsx
+++ b/apps/app/src/Navigation.tsx
@@ -2,7 +2,9 @@ import Feather from "@expo/vector-icons/Feather";
 import MaterialIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { BottomTabBar, createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useAtomValue } from "jotai";
 import { View } from "react-native";
+import { profileAtom } from "./atoms/profile";
 import { colors } from "./theme";
 import MiniPlayer from "./components/MiniPlayer";
 import AlbumDetails from "./screens/AlbumDetails";
@@ -10,6 +12,7 @@ import ArtistDetails from "./screens/ArtistDetails";
 import Charts from "./screens/Charts";
 import Home from "./screens/Home";
 import Profile from "./screens/Profile";
+import Recommendations from "./screens/Recommendations";
 import Search from "./screens/Search";
 import SongDetails from "./screens/SongDetails";
 import Story from "./screens/Story";
@@ -18,6 +21,7 @@ const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();
 const HomeStack = createNativeStackNavigator();
 const ChartsStack = createNativeStackNavigator();
+const RecommendationsStack = createNativeStackNavigator();
 const ProfileStack = createNativeStackNavigator();
 const SearchStack = createNativeStackNavigator();
 
@@ -76,6 +80,24 @@ function ProfileStackScreen() {
   );
 }
 
+function RecommendationsStackScreen() {
+  return (
+    <RecommendationsStack.Navigator
+      screenOptions={{
+        contentStyle: { backgroundColor: colors.background },
+        headerShown: false,
+        animation: "default",
+      }}
+    >
+      <RecommendationsStack.Screen name="Recommendations" component={Recommendations} />
+      <RecommendationsStack.Screen name="AlbumDetails" component={AlbumDetails} />
+      <RecommendationsStack.Screen name="ArtistDetails" component={ArtistDetails} />
+      <RecommendationsStack.Screen name="SongDetails" component={SongDetails} />
+      <RecommendationsStack.Screen name="UserProfile" component={Profile} />
+    </RecommendationsStack.Navigator>
+  );
+}
+
 function SearchStackScreen() {
   return (
     <SearchStack.Navigator
@@ -111,6 +133,8 @@ function CustomTabBar(props: any) {
 }
 
 function HomeTabs() {
+  const profile = useAtomValue(profileAtom);
+
   return (
     <Tab.Navigator
       tabBar={(props) => <CustomTabBar {...props} />}
@@ -135,6 +159,8 @@ function HomeTabs() {
           switch (route.name) {
             case "HomeTab":
               return <MaterialIcons name="home-variant-outline" size={24} color={color} />;
+            case "RecommendationsTab":
+              return <MaterialIcons name="star-shooting-outline" size={24} color={color} />;
             case "ChartsTab":
               return <MaterialIcons name="chart-bar" size={24} color={color} />;
             case "SearchTab":
@@ -144,17 +170,14 @@ function HomeTabs() {
           }
         },
         tabBarLabel: ({ color }) => {
-          const labels: Record<string, string> = {
-            HomeTab: "Home",
-            ChartsTab: "Charts",
-            SearchTab: "Search",
-            ProfileTab: "Profile",
-          };
           return null; // Use default label from tabBarLabel below
         },
       })}
     >
       <Tab.Screen name="HomeTab" component={HomeStackScreen} options={{ tabBarLabel: "Home" }} />
+      {!!profile && (
+        <Tab.Screen name="RecommendationsTab" component={RecommendationsStackScreen} options={{ tabBarLabel: "For You" }} />
+      )}
       <Tab.Screen name="ChartsTab" component={ChartsStackScreen} options={{ tabBarLabel: "Charts" }} />
       <Tab.Screen name="SearchTab" component={SearchStackScreen} options={{ tabBarLabel: "Search" }} />
       <Tab.Screen name="ProfileTab" component={ProfileStackScreen} options={{ tabBarLabel: "Profile" }} />
@@ -179,6 +202,7 @@ export type RootStackParamList = {
   Home: undefined;
   HomeTabs: undefined;
   Charts: undefined;
+  Recommendations: undefined;
   AlbumDetails: { uri: string };
   ArtistDetails: { uri: string };
   SongDetails: { uri: string };

--- a/apps/app/src/hooks/useRecommendations.tsx
+++ b/apps/app/src/hooks/useRecommendations.tsx
@@ -1,0 +1,86 @@
+import { useQuery } from "@tanstack/react-query";
+import { client } from "../api";
+import { storage } from "../storage";
+
+export type TrackRecommendation = {
+  title?: string;
+  artist?: string;
+  album?: string;
+  albumArt?: string;
+  trackUri?: string;
+  artistUri?: string;
+  albumUri?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  source?: string;
+  likesCount?: number;
+};
+
+export type ArtistRecommendation = {
+  id?: string;
+  uri?: string;
+  name?: string;
+  picture?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  source?: string;
+};
+
+export type AlbumRecommendation = {
+  id?: string;
+  uri?: string;
+  title?: string;
+  artist?: string;
+  artistUri?: string;
+  year?: number;
+  albumArt?: string;
+  recommendationScore?: number;
+  source?: string;
+};
+
+const authHeaders = () => {
+  const token = storage.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+export const useTrackRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["trackRecommendations", did],
+    queryFn: () =>
+      client
+        .get<{ recommendations: TrackRecommendation[] }>(
+          "/xrpc/app.rocksky.feed.getRecommendations",
+          { params: { did, limit: 50 }, headers: authHeaders() },
+        )
+        .then((r) => r.data.recommendations ?? []),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useArtistRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["artistRecommendations", did],
+    queryFn: () =>
+      client
+        .get<{ artists: ArtistRecommendation[] }>(
+          "/xrpc/app.rocksky.feed.getArtistRecommendations",
+          { params: { did, limit: 50 }, headers: authHeaders() },
+        )
+        .then((r) => r.data.artists ?? []),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useAlbumRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["albumRecommendations", did],
+    queryFn: () =>
+      client
+        .get<{ albums: AlbumRecommendation[] }>(
+          "/xrpc/app.rocksky.feed.getAlbumRecommendations",
+          { params: { did, limit: 50 }, headers: authHeaders() },
+        )
+        .then((r) => r.data.albums ?? []),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/apps/app/src/screens/Recommendations/Recommendations.tsx
+++ b/apps/app/src/screens/Recommendations/Recommendations.tsx
@@ -1,0 +1,261 @@
+import { profileAtom } from "@/src/atoms/profile";
+import { Text } from "@/src/components/Text";
+import {
+  useAlbumRecommendationsQuery,
+  useArtistRecommendationsQuery,
+  useTrackRecommendationsQuery,
+  type AlbumRecommendation,
+  type ArtistRecommendation,
+  type TrackRecommendation,
+} from "@/src/hooks/useRecommendations";
+import { RootStackParamList } from "@/src/Navigation";
+import { colors } from "@/src/theme";
+import { NavigationProp, useNavigation } from "@react-navigation/native";
+import { Image } from "expo-image";
+import { useAtomValue } from "jotai";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  SafeAreaView,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+function sourceLabel(source?: string): { text: string; bg: string; fg: string } {
+  switch (source) {
+    case "neighbour":
+    case "known-artist":
+      return { text: source === "neighbour" ? "Neighbour" : "Known artist", bg: "#16a34a22", fg: "#16a34a" };
+    case "new-artist":
+    case "social":
+      return { text: source === "new-artist" ? "New artist" : "Social", bg: "#2563eb22", fg: "#2563eb" };
+    case "serendipity":
+      return { text: "Serendipity", bg: "#7c3aed22", fg: "#7c3aed" };
+    default:
+      return { text: "For you", bg: `${colors.textMuted}22`, fg: colors.textMuted };
+  }
+}
+
+function SourceBadge({ source }: { source?: string }) {
+  const { text, bg, fg } = sourceLabel(source);
+  return (
+    <View style={{ backgroundColor: bg, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 20 }}>
+      <Text style={{ fontSize: 10, fontWeight: "700", color: fg }}>{text}</Text>
+    </View>
+  );
+}
+
+function TrackRow({
+  item,
+  onPress,
+}: {
+  item: TrackRecommendation;
+  onPress: (uri: string) => void;
+}) {
+  const cover = item.albumArt;
+  return (
+    <TouchableOpacity
+      onPress={() => item.trackUri && onPress(item.trackUri)}
+      style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, paddingHorizontal: 16, gap: 12 }}
+    >
+      <View style={{ width: 44, height: 44, borderRadius: 8, overflow: "hidden", backgroundColor: colors.surface2 }}>
+        {cover ? (
+          <Image source={{ uri: cover }} style={{ width: 44, height: 44 }} />
+        ) : (
+          <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+            <Text style={{ opacity: 0.2, fontSize: 18 }}>♪</Text>
+          </View>
+        )}
+      </View>
+      <View style={{ flex: 1 }}>
+        <Text numberOfLines={1} style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>{item.title}</Text>
+        <Text numberOfLines={1} style={{ fontSize: 12, color: colors.textMuted }}>
+          {item.artist}{item.album ? ` — ${item.album}` : ""}
+        </Text>
+      </View>
+      <SourceBadge source={item.source} />
+    </TouchableOpacity>
+  );
+}
+
+function ArtistRow({
+  item,
+  onPress,
+}: {
+  item: ArtistRecommendation;
+  onPress: (uri: string) => void;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={() => item.uri && onPress(item.uri)}
+      style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, paddingHorizontal: 16, gap: 12 }}
+    >
+      <View style={{ width: 44, height: 44, borderRadius: 22, overflow: "hidden", backgroundColor: colors.surface2 }}>
+        {item.picture ? (
+          <Image source={{ uri: item.picture }} style={{ width: 44, height: 44 }} />
+        ) : (
+          <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+            <Text style={{ opacity: 0.2, fontSize: 18 }}>♬</Text>
+          </View>
+        )}
+      </View>
+      <View style={{ flex: 1 }}>
+        <Text numberOfLines={1} style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>{item.name}</Text>
+        {item.genres && item.genres.length > 0 && (
+          <Text numberOfLines={1} style={{ fontSize: 12, color: colors.textMuted }}>
+            {item.genres.slice(0, 3).join(", ")}
+          </Text>
+        )}
+      </View>
+      <SourceBadge source={item.source} />
+    </TouchableOpacity>
+  );
+}
+
+function AlbumRow({
+  item,
+  onPress,
+}: {
+  item: AlbumRecommendation;
+  onPress: (uri: string) => void;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={() => item.uri && onPress(item.uri)}
+      style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, paddingHorizontal: 16, gap: 12 }}
+    >
+      <View style={{ width: 44, height: 44, borderRadius: 8, overflow: "hidden", backgroundColor: colors.surface2 }}>
+        {item.albumArt ? (
+          <Image source={{ uri: item.albumArt }} style={{ width: 44, height: 44 }} />
+        ) : (
+          <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+            <Text style={{ opacity: 0.2, fontSize: 18 }}>💿</Text>
+          </View>
+        )}
+      </View>
+      <View style={{ flex: 1 }}>
+        <Text numberOfLines={1} style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>{item.title}</Text>
+        <Text numberOfLines={1} style={{ fontSize: 12, color: colors.textMuted }}>
+          {item.artist}{item.year ? ` · ${item.year}` : ""}
+        </Text>
+      </View>
+      <SourceBadge source={item.source} />
+    </TouchableOpacity>
+  );
+}
+
+export default function Recommendations() {
+  const profile = useAtomValue(profileAtom);
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const [tab, setTab] = useState<"tracks" | "artists" | "albums">("tracks");
+
+  const did = profile?.did;
+  const { data: tracks, isLoading: tracksLoading } = useTrackRecommendationsQuery(did);
+  const { data: artists, isLoading: artistsLoading } = useArtistRecommendationsQuery(did);
+  const { data: albums, isLoading: albumsLoading } = useAlbumRecommendationsQuery(did);
+
+  const onPressTrack = (uri: string) => {
+    navigation.navigate("SongDetails", { uri: `at://${uri.replace("at://", "")}` });
+  };
+
+  const onPressArtist = (uri: string) => {
+    navigation.navigate("ArtistDetails", { uri: `at://${uri.replace("at://", "")}` });
+  };
+
+  const onPressAlbum = (uri: string) => {
+    navigation.navigate("AlbumDetails", { uri: `at://${uri.replace("at://", "")}` });
+  };
+
+  if (!profile) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, alignItems: "center", justifyContent: "center", padding: 24 }}>
+        <Text style={{ fontSize: 16, fontWeight: "600", color: colors.text, textAlign: "center", marginBottom: 8 }}>
+          Sign in to see your recommendations
+        </Text>
+        <Text style={{ fontSize: 13, color: colors.textMuted, textAlign: "center" }}>
+          Personalised picks based on your scrobble history.
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
+  const loading =
+    tab === "tracks" ? tracksLoading : tab === "artists" ? artistsLoading : albumsLoading;
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 }}>
+        <Text style={{ fontSize: 24, fontWeight: "800", color: colors.text, marginBottom: 16 }}>
+          For You
+        </Text>
+
+        <View style={{ flexDirection: "row", gap: 8 }}>
+          {(["tracks", "artists", "albums"] as const).map((t) => (
+            <TouchableOpacity
+              key={t}
+              onPress={() => setTab(t)}
+              style={{
+                paddingHorizontal: 14,
+                paddingVertical: 6,
+                borderRadius: 20,
+                backgroundColor: tab === t ? colors.primary : colors.surface2,
+              }}
+            >
+              <Text style={{
+                fontSize: 13,
+                fontWeight: "600",
+                color: tab === t ? "#fff" : colors.textMuted,
+                textTransform: "capitalize",
+              }}>
+                {t}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : tab === "tracks" ? (
+        <FlatList
+          data={tracks ?? []}
+          keyExtractor={(item, i) => item.trackUri ?? String(i)}
+          renderItem={({ item }) => <TrackRow item={item} onPress={onPressTrack} />}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <Text style={{ padding: 16, color: colors.textMuted, fontSize: 14 }}>
+              Scrobble more tracks to unlock recommendations.
+            </Text>
+          }
+        />
+      ) : tab === "artists" ? (
+        <FlatList
+          data={artists ?? []}
+          keyExtractor={(item, i) => item.id ?? String(i)}
+          renderItem={({ item }) => <ArtistRow item={item} onPress={onPressArtist} />}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <Text style={{ padding: 16, color: colors.textMuted, fontSize: 14 }}>
+              Scrobble more tracks to unlock recommendations.
+            </Text>
+          }
+        />
+      ) : (
+        <FlatList
+          data={albums ?? []}
+          keyExtractor={(item, i) => item.id ?? String(i)}
+          renderItem={({ item }) => <AlbumRow item={item} onPress={onPressAlbum} />}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <Text style={{ padding: 16, color: colors.textMuted, fontSize: 14 }}>
+              Scrobble more tracks to unlock recommendations.
+            </Text>
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+}

--- a/apps/app/src/screens/Recommendations/index.tsx
+++ b/apps/app/src/screens/Recommendations/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Recommendations";

--- a/apps/beta/bun.lock
+++ b/apps/beta/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tiny-salad-4531",

--- a/apps/web-mobile/src/App.tsx
+++ b/apps/web-mobile/src/App.tsx
@@ -5,6 +5,7 @@ import Charts from "./pages/charts";
 import HomePage from "./pages/home";
 import Me from "./pages/me";
 import ProfilePage from "./pages/profile";
+import Recommendations from "./pages/recommendations";
 import Search from "./pages/search";
 import SongPage from "./pages/song";
 
@@ -14,6 +15,7 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/charts" element={<Charts />} />
+        <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/search" element={<Search />} />
         <Route path="/me" element={<Me />} />
         <Route path="/:did/scrobble/:rkey" element={<SongPage />} />

--- a/apps/web-mobile/src/api/recommendations.ts
+++ b/apps/web-mobile/src/api/recommendations.ts
@@ -1,0 +1,82 @@
+import { client } from ".";
+
+export type TrackRecommendation = {
+  title?: string;
+  artist?: string;
+  album?: string;
+  albumArt?: string;
+  trackUri?: string;
+  artistUri?: string;
+  albumUri?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  source?: string;
+  likesCount?: number;
+};
+
+export type ArtistRecommendation = {
+  id?: string;
+  uri?: string;
+  name?: string;
+  picture?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  source?: string;
+};
+
+export type AlbumRecommendation = {
+  id?: string;
+  uri?: string;
+  title?: string;
+  artist?: string;
+  artistUri?: string;
+  year?: number;
+  albumArt?: string;
+  recommendationScore?: number;
+  source?: string;
+};
+
+export const getTrackRecommendations = (did: string, limit = 50) =>
+  client
+    .get<{ recommendations: TrackRecommendation[] }>(
+      "/xrpc/app.rocksky.feed.getRecommendations",
+      {
+        params: { did, limit },
+        headers: {
+          Authorization: localStorage.getItem("token")
+            ? `Bearer ${localStorage.getItem("token")}`
+            : undefined,
+        },
+      },
+    )
+    .then((r) => r.data.recommendations ?? []);
+
+export const getArtistRecommendations = (did: string, limit = 50) =>
+  client
+    .get<{ artists: ArtistRecommendation[] }>(
+      "/xrpc/app.rocksky.feed.getArtistRecommendations",
+      {
+        params: { did, limit },
+        headers: {
+          Authorization: localStorage.getItem("token")
+            ? `Bearer ${localStorage.getItem("token")}`
+            : undefined,
+        },
+      },
+    )
+    .then((r) => r.data.artists ?? []);
+
+export const getAlbumRecommendations = (did: string, limit = 50) =>
+  client
+    .get<{ albums: AlbumRecommendation[] }>(
+      "/xrpc/app.rocksky.feed.getAlbumRecommendations",
+      {
+        params: { did, limit },
+        headers: {
+          Authorization: localStorage.getItem("token")
+            ? `Bearer ${localStorage.getItem("token")}`
+            : undefined,
+        },
+      },
+    )
+    .then((r) => r.data.albums ?? []);

--- a/apps/web-mobile/src/components/BottomNav/index.tsx
+++ b/apps/web-mobile/src/components/BottomNav/index.tsx
@@ -2,19 +2,35 @@ import {
   IconChartBar,
   IconHome,
   IconSearch,
+  IconSparkles,
   IconUser,
 } from "@tabler/icons-react";
+import { useAtomValue } from "jotai";
 import { Link, useLocation } from "react-router-dom";
-
-const tabs = [
-  { to: "/", icon: IconHome, label: "Home" },
-  { to: "/charts", icon: IconChartBar, label: "Charts" },
-  { to: "/search", icon: IconSearch, label: "Search" },
-  { to: "/me", icon: IconUser, label: "Profile" },
-];
+import { profileAtom } from "../../atoms/profile";
 
 export default function BottomNav() {
   const location = useLocation();
+  const profile = useAtomValue(profileAtom);
+  const jwt = localStorage.getItem("token");
+
+  const baseTabs = [
+    { to: "/", icon: IconHome, label: "Home" },
+    { to: "/charts", icon: IconChartBar, label: "Charts" },
+    { to: "/search", icon: IconSearch, label: "Search" },
+    { to: "/me", icon: IconUser, label: "Profile" },
+  ];
+
+  const tabs =
+    profile && jwt
+      ? [
+          baseTabs[0],
+          { to: "/recommendations", icon: IconSparkles, label: "For You" },
+          baseTabs[1],
+          baseTabs[2],
+          baseTabs[3],
+        ]
+      : baseTabs;
 
   return (
     <nav

--- a/apps/web-mobile/src/hooks/useRecommendations.tsx
+++ b/apps/web-mobile/src/hooks/useRecommendations.tsx
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getAlbumRecommendations,
+  getArtistRecommendations,
+  getTrackRecommendations,
+} from "../api/recommendations";
+
+export const useTrackRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["trackRecommendations", did],
+    queryFn: () => getTrackRecommendations(did!),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useArtistRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["artistRecommendations", did],
+    queryFn: () => getArtistRecommendations(did!),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useAlbumRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["albumRecommendations", did],
+    queryFn: () => getAlbumRecommendations(did!),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/apps/web-mobile/src/pages/recommendations/index.tsx
+++ b/apps/web-mobile/src/pages/recommendations/index.tsx
@@ -1,0 +1,275 @@
+import ContentLoader from "react-content-loader";
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useAtomValue } from "jotai";
+import { profileAtom } from "../../atoms/profile";
+import Main from "../../layouts/Main";
+import {
+  useAlbumRecommendationsQuery,
+  useArtistRecommendationsQuery,
+  useTrackRecommendationsQuery,
+} from "../../hooks/useRecommendations";
+import type {
+  AlbumRecommendation,
+  ArtistRecommendation,
+  TrackRecommendation,
+} from "../../api/recommendations";
+
+function sourceLabel(source?: string): { text: string; color: string } {
+  switch (source) {
+    case "neighbour":
+    case "known-artist":
+      return { text: source === "neighbour" ? "Neighbour" : "Known artist", color: "#16a34a" };
+    case "new-artist":
+    case "social":
+      return { text: source === "new-artist" ? "New artist" : "Social", color: "#2563eb" };
+    case "serendipity":
+      return { text: "Serendipity", color: "#7c3aed" };
+    default:
+      return { text: "For you", color: "var(--color-text-muted)" };
+  }
+}
+
+function SourceBadge({ source }: { source?: string }) {
+  const { text, color } = sourceLabel(source);
+  return (
+    <span
+      className="text-[10px] font-semibold px-[6px] py-[2px] rounded-full shrink-0"
+      style={{ backgroundColor: `${color}22`, color }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div className="px-4">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <ContentLoader
+          key={i}
+          width="100%"
+          height={64}
+          viewBox="0 0 350 64"
+          backgroundColor="var(--color-skeleton-background)"
+          foregroundColor="var(--color-skeleton-foreground)"
+        >
+          <rect x="0" y="10" rx="6" ry="6" width="44" height="44" />
+          <rect x="56" y="14" rx="4" ry="4" width="160" height="12" />
+          <rect x="56" y="34" rx="4" ry="4" width="100" height="10" />
+          <rect x="270" y="18" rx="10" ry="10" width="80" height="18" />
+        </ContentLoader>
+      ))}
+    </div>
+  );
+}
+
+function TrackRow({ item }: { item: TrackRecommendation }) {
+  const href = item.trackUri
+    ? `/${item.trackUri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3 border-b px-4"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="w-11 h-11 rounded-lg overflow-hidden shrink-0 flex items-center justify-center text-xl"
+        style={{ backgroundColor: "var(--color-surface-2)" }}
+      >
+        {item.albumArt ? (
+          <img src={item.albumArt} alt={item.title} className="w-full h-full object-cover" />
+        ) : (
+          <span className="opacity-20">♪</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {href ? (
+          <Link to={href} className="no-underline block font-semibold text-sm truncate" style={{ color: "var(--color-text)" }}>
+            {item.title}
+          </Link>
+        ) : (
+          <p className="font-semibold text-sm truncate m-0" style={{ color: "var(--color-text)" }}>{item.title}</p>
+        )}
+        <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
+          {item.artist}{item.album ? ` — ${item.album}` : ""}
+        </p>
+      </div>
+      <SourceBadge source={item.source} />
+    </div>
+  );
+}
+
+function ArtistRow({ item }: { item: ArtistRecommendation }) {
+  const href = item.uri
+    ? `/${item.uri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3 border-b px-4"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="w-11 h-11 rounded-full overflow-hidden shrink-0 flex items-center justify-center text-xl"
+        style={{ backgroundColor: "var(--color-surface-2)" }}
+      >
+        {item.picture ? (
+          <img src={item.picture} alt={item.name} className="w-full h-full object-cover" />
+        ) : (
+          <span className="opacity-20">♬</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {href ? (
+          <Link to={href} className="no-underline font-semibold text-sm truncate block" style={{ color: "var(--color-text)" }}>
+            {item.name}
+          </Link>
+        ) : (
+          <p className="font-semibold text-sm truncate m-0" style={{ color: "var(--color-text)" }}>{item.name}</p>
+        )}
+        {item.genres && item.genres.length > 0 && (
+          <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
+            {item.genres.slice(0, 3).join(", ")}
+          </p>
+        )}
+      </div>
+      <SourceBadge source={item.source} />
+    </div>
+  );
+}
+
+function AlbumRow({ item }: { item: AlbumRecommendation }) {
+  const href = item.uri
+    ? `/${item.uri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3 border-b px-4"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="w-11 h-11 rounded-lg overflow-hidden shrink-0 flex items-center justify-center text-xl"
+        style={{ backgroundColor: "var(--color-surface-2)" }}
+      >
+        {item.albumArt ? (
+          <img src={item.albumArt} alt={item.title} className="w-full h-full object-cover" />
+        ) : (
+          <span className="opacity-20">💿</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {href ? (
+          <Link to={href} className="no-underline font-semibold text-sm truncate block" style={{ color: "var(--color-text)" }}>
+            {item.title}
+          </Link>
+        ) : (
+          <p className="font-semibold text-sm truncate m-0" style={{ color: "var(--color-text)" }}>{item.title}</p>
+        )}
+        <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
+          {item.artist}{item.year ? ` · ${item.year}` : ""}
+        </p>
+      </div>
+      <SourceBadge source={item.source} />
+    </div>
+  );
+}
+
+export default function Recommendations() {
+  const profile = useAtomValue(profileAtom);
+  const jwt = localStorage.getItem("token");
+  const [tab, setTab] = useState<"tracks" | "artists" | "albums">("tracks");
+
+  const did = profile?.did;
+  const { data: tracks, isLoading: tracksLoading } = useTrackRecommendationsQuery(did);
+  const { data: artists, isLoading: artistsLoading } = useArtistRecommendationsQuery(did);
+  const { data: albums, isLoading: albumsLoading } = useAlbumRecommendationsQuery(did);
+
+  if (!profile || !jwt) {
+    return (
+      <Main>
+        <div className="flex flex-col items-center justify-center py-24 px-4 text-center">
+          <p className="text-lg font-semibold" style={{ color: "var(--color-text)" }}>
+            Sign in to see your personalised recommendations
+          </p>
+          <p className="text-sm mt-2" style={{ color: "var(--color-text-muted)" }}>
+            Recommendations are based on your scrobble history.
+          </p>
+        </div>
+      </Main>
+    );
+  }
+
+  const loading =
+    tab === "tracks" ? tracksLoading : tab === "artists" ? artistsLoading : albumsLoading;
+
+  const empty =
+    tab === "tracks"
+      ? (tracks ?? []).length === 0
+      : tab === "artists"
+        ? (artists ?? []).length === 0
+        : (albums ?? []).length === 0;
+
+  return (
+    <Main>
+      <div className="pt-4 pb-6">
+        <h1
+          className="px-4 text-2xl font-bold m-0 mb-4"
+          style={{ color: "var(--color-text)" }}
+        >
+          Recommendations
+        </h1>
+
+        <div className="flex gap-2 px-4 mb-4">
+          {(["tracks", "artists", "albums"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className="text-sm font-medium px-4 py-1.5 rounded-full border-none cursor-pointer capitalize"
+              style={{
+                backgroundColor: tab === t ? "var(--color-primary)" : "var(--color-surface-2)",
+                color: tab === t ? "#fff" : "var(--color-text-muted)",
+              }}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+
+        {loading && <ListSkeleton />}
+
+        {!loading && empty && (
+          <p className="px-4 text-sm" style={{ color: "var(--color-text-muted)" }}>
+            Scrobble more tracks to unlock personalised recommendations.
+          </p>
+        )}
+
+        {!loading && !empty && tab === "tracks" && (
+          <div>
+            {(tracks ?? []).map((item, i) => (
+              <TrackRow key={item.trackUri ?? i} item={item} />
+            ))}
+          </div>
+        )}
+
+        {!loading && !empty && tab === "artists" && (
+          <div>
+            {(artists ?? []).map((item, i) => (
+              <ArtistRow key={item.id ?? i} item={item} />
+            ))}
+          </div>
+        )}
+
+        {!loading && !empty && tab === "albums" && (
+          <div>
+            {(albums ?? []).map((item, i) => (
+              <AlbumRow key={item.id ?? i} item={item} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Main>
+  );
+}

--- a/apps/web/src/api/recommendations.ts
+++ b/apps/web/src/api/recommendations.ts
@@ -1,0 +1,82 @@
+import { client } from ".";
+
+export type TrackRecommendation = {
+  title?: string;
+  artist?: string;
+  album?: string;
+  albumArt?: string;
+  trackUri?: string;
+  artistUri?: string;
+  albumUri?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  source?: string;
+  likesCount?: number;
+};
+
+export type ArtistRecommendation = {
+  id?: string;
+  uri?: string;
+  name?: string;
+  picture?: string;
+  genres?: string[];
+  recommendationScore?: number;
+  source?: string;
+};
+
+export type AlbumRecommendation = {
+  id?: string;
+  uri?: string;
+  title?: string;
+  artist?: string;
+  artistUri?: string;
+  year?: number;
+  albumArt?: string;
+  recommendationScore?: number;
+  source?: string;
+};
+
+export const getTrackRecommendations = (did: string, limit = 50) =>
+  client
+    .get<{ recommendations: TrackRecommendation[] }>(
+      "/xrpc/app.rocksky.feed.getRecommendations",
+      {
+        params: { did, limit },
+        headers: {
+          Authorization: localStorage.getItem("token")
+            ? `Bearer ${localStorage.getItem("token")}`
+            : undefined,
+        },
+      },
+    )
+    .then((r) => r.data.recommendations ?? []);
+
+export const getArtistRecommendations = (did: string, limit = 50) =>
+  client
+    .get<{ artists: ArtistRecommendation[] }>(
+      "/xrpc/app.rocksky.feed.getArtistRecommendations",
+      {
+        params: { did, limit },
+        headers: {
+          Authorization: localStorage.getItem("token")
+            ? `Bearer ${localStorage.getItem("token")}`
+            : undefined,
+        },
+      },
+    )
+    .then((r) => r.data.artists ?? []);
+
+export const getAlbumRecommendations = (did: string, limit = 50) =>
+  client
+    .get<{ albums: AlbumRecommendation[] }>(
+      "/xrpc/app.rocksky.feed.getAlbumRecommendations",
+      {
+        params: { did, limit },
+        headers: {
+          Authorization: localStorage.getItem("token")
+            ? `Bearer ${localStorage.getItem("token")}`
+            : undefined,
+        },
+      },
+    )
+    .then((r) => r.data.albums ?? []);

--- a/apps/web/src/hooks/useRecommendations.tsx
+++ b/apps/web/src/hooks/useRecommendations.tsx
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getAlbumRecommendations,
+  getArtistRecommendations,
+  getTrackRecommendations,
+} from "../api/recommendations";
+
+export const useTrackRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["trackRecommendations", did],
+    queryFn: () => getTrackRecommendations(did!),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useArtistRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["artistRecommendations", did],
+    queryFn: () => getArtistRecommendations(did!),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useAlbumRecommendationsQuery = (did: string | undefined) =>
+  useQuery({
+    queryKey: ["albumRecommendations", did],
+    queryFn: () => getAlbumRecommendations(did!),
+    enabled: !!did,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/apps/web/src/layouts/Navbar/Navbar.tsx
+++ b/apps/web/src/layouts/Navbar/Navbar.tsx
@@ -157,6 +157,19 @@ function Navbar() {
         </Link>
       </div>
       <div className="flex-1"></div>
+      {profile && jwt && profile.did === "did:plc:7vdlgi2bflelz7mmuxoqjfcr" && (
+        <div className="mr-[20px]">
+          <Link
+            to="/recommendations"
+            className="text-[var(--color-text)] text-[16px] opacity-90 hover:opacity-100"
+            style={{ textDecoration: "none" }}
+          >
+            <AnimatedLink>
+              <b>Recommendations</b>
+            </AnimatedLink>
+          </Link>
+        </div>
+      )}
       <div>
         <Link
           to="/charts"

--- a/apps/web/src/pages/recommendations/Recommendations.tsx
+++ b/apps/web/src/pages/recommendations/Recommendations.tsx
@@ -1,0 +1,309 @@
+import ContentLoader from "react-content-loader";
+import { Link } from "@tanstack/react-router";
+import { HeadingMedium } from "baseui/typography";
+import { Tab, Tabs } from "baseui/tabs-motion";
+import { useAtomValue } from "jotai";
+import { useState } from "react";
+import { profileAtom } from "../../atoms/profile";
+import Main from "../../layouts/Main";
+import {
+  useAlbumRecommendationsQuery,
+  useArtistRecommendationsQuery,
+  useTrackRecommendationsQuery,
+} from "../../hooks/useRecommendations";
+import type {
+  AlbumRecommendation,
+  ArtistRecommendation,
+  TrackRecommendation,
+} from "../../api/recommendations";
+
+function sourceLabel(source?: string): { text: string; color: string } {
+  switch (source) {
+    case "neighbour":
+    case "known-artist":
+      return { text: source === "neighbour" ? "Neighbour pick" : "Known artist", color: "#16a34a" };
+    case "new-artist":
+    case "social":
+      return { text: source === "new-artist" ? "New artist" : "Social", color: "#2563eb" };
+    case "serendipity":
+      return { text: "Serendipity", color: "#7c3aed" };
+    default:
+      return { text: "For you", color: "var(--color-text-muted)" };
+  }
+}
+
+function SourceBadge({ source }: { source?: string }) {
+  const { text, color } = sourceLabel(source);
+  return (
+    <span
+      className="text-[11px] font-semibold px-[7px] py-[2px] rounded-full"
+      style={{ backgroundColor: `${color}22`, color }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <ContentLoader
+          key={i}
+          width="100%"
+          height={70}
+          viewBox="0 0 700 70"
+          backgroundColor="var(--color-skeleton-background)"
+          foregroundColor="var(--color-skeleton-foreground)"
+        >
+          <rect x="0" y="13" rx="6" ry="6" width="44" height="44" />
+          <rect x="60" y="16" rx="4" ry="4" width="240" height="14" />
+          <rect x="60" y="38" rx="4" ry="4" width="160" height="11" />
+          <rect x="560" y="22" rx="10" ry="10" width="100" height="18" />
+        </ContentLoader>
+      ))}
+    </div>
+  );
+}
+
+function TrackRow({ item }: { item: TrackRecommendation }) {
+  const href = item.trackUri
+    ? `/${item.trackUri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+  const artistHref = item.artistUri
+    ? `/${item.artistUri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3 border-b"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="w-11 h-11 rounded-lg overflow-hidden shrink-0 flex items-center justify-center"
+        style={{ backgroundColor: "var(--color-menu-hover)" }}
+      >
+        {item.albumArt ? (
+          <img src={item.albumArt} alt={item.title} className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-xl opacity-20">♪</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {href ? (
+          <Link to={href as any} className="no-underline block font-semibold text-[14px] truncate !text-[var(--color-text)]">
+            {item.title}
+          </Link>
+        ) : (
+          <p className="font-semibold text-[14px] truncate m-0" style={{ color: "var(--color-text)" }}>{item.title}</p>
+        )}
+        <div className="flex items-center gap-1">
+          {artistHref ? (
+            <Link to={artistHref as any} className="no-underline text-[12px] truncate !text-[var(--color-text-muted)]">
+              {item.artist}
+            </Link>
+          ) : (
+            <span className="text-[12px] truncate" style={{ color: "var(--color-text-muted)" }}>{item.artist}</span>
+          )}
+          {item.album && (
+            <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>
+              — {item.album}
+            </span>
+          )}
+        </div>
+      </div>
+      <SourceBadge source={item.source} />
+    </div>
+  );
+}
+
+function ArtistRow({ item }: { item: ArtistRecommendation }) {
+  const href = item.uri
+    ? `/${item.uri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3 border-b"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="w-11 h-11 rounded-full overflow-hidden shrink-0 flex items-center justify-center"
+        style={{ backgroundColor: "var(--color-menu-hover)" }}
+      >
+        {item.picture ? (
+          <img src={item.picture} alt={item.name} className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-xl opacity-20">♬</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {href ? (
+          <Link to={href as any} className="no-underline font-semibold text-[14px] truncate block !text-[var(--color-text)]">
+            {item.name}
+          </Link>
+        ) : (
+          <p className="font-semibold text-[14px] truncate m-0" style={{ color: "var(--color-text)" }}>{item.name}</p>
+        )}
+        {item.genres && item.genres.length > 0 && (
+          <p className="text-[12px] truncate m-0" style={{ color: "var(--color-text-muted)" }}>
+            {item.genres.slice(0, 3).join(", ")}
+          </p>
+        )}
+      </div>
+      <SourceBadge source={item.source} />
+    </div>
+  );
+}
+
+function AlbumRow({ item }: { item: AlbumRecommendation }) {
+  const href = item.uri
+    ? `/${item.uri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+  const artistHref = item.artistUri
+    ? `/${item.artistUri.split("at://")[1]?.replace("app.rocksky.", "")}`
+    : null;
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3 border-b"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="w-11 h-11 rounded-lg overflow-hidden shrink-0 flex items-center justify-center"
+        style={{ backgroundColor: "var(--color-menu-hover)" }}
+      >
+        {item.albumArt ? (
+          <img src={item.albumArt} alt={item.title} className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-xl opacity-20">💿</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {href ? (
+          <Link to={href as any} className="no-underline font-semibold text-[14px] truncate block !text-[var(--color-text)]">
+            {item.title}
+          </Link>
+        ) : (
+          <p className="font-semibold text-[14px] truncate m-0" style={{ color: "var(--color-text)" }}>{item.title}</p>
+        )}
+        <div className="flex items-center gap-1">
+          {artistHref ? (
+            <Link to={artistHref as any} className="no-underline text-[12px] !text-[var(--color-text-muted)]">
+              {item.artist}
+            </Link>
+          ) : (
+            <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>{item.artist}</span>
+          )}
+          {item.year && (
+            <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>
+              · {item.year}
+            </span>
+          )}
+        </div>
+      </div>
+      <SourceBadge source={item.source} />
+    </div>
+  );
+}
+
+const TAB_STYLE = {
+  color: "var(--color-text)",
+  backgroundColor: "var(--color-background) !important",
+};
+
+function Recommendations() {
+  const profile = useAtomValue(profileAtom);
+  const [activeKey, setActiveKey] = useState<React.Key>("0");
+
+  const did = profile?.did;
+  const { data: tracks, isLoading: tracksLoading } = useTrackRecommendationsQuery(did);
+  const { data: artists, isLoading: artistsLoading } = useArtistRecommendationsQuery(did);
+  const { data: albums, isLoading: albumsLoading } = useAlbumRecommendationsQuery(did);
+
+  return (
+    <Main>
+      <div className="mt-[60px] mb-[100px]">
+        <HeadingMedium
+          marginTop="0px"
+          marginBottom="35px"
+          className="!text-[var(--color-text)]"
+        >
+          Recommendations
+        </HeadingMedium>
+
+        <Tabs
+          activeKey={activeKey}
+          onChange={({ activeKey }) => setActiveKey(activeKey)}
+          overrides={{
+            TabHighlight: { style: { backgroundColor: "var(--color-purple)" } },
+            TabBorder: { style: { display: "none" } },
+          }}
+          activateOnFocus
+        >
+          <Tab
+            title="Tracks"
+            overrides={{ Tab: { style: TAB_STYLE } }}
+          >
+            {tracksLoading ? (
+              <ListSkeleton />
+            ) : (
+              <div className="mt-[10px]">
+                {(tracks ?? []).map((item, i) => (
+                  <TrackRow key={item.trackUri ?? i} item={item} />
+                ))}
+                {(tracks ?? []).length === 0 && (
+                  <p className="text-[var(--color-text-muted)]">
+                    Scrobble more tracks to unlock personalised recommendations.
+                  </p>
+                )}
+              </div>
+            )}
+          </Tab>
+
+          <Tab
+            title="Artists"
+            overrides={{ Tab: { style: TAB_STYLE } }}
+          >
+            {artistsLoading ? (
+              <ListSkeleton />
+            ) : (
+              <div className="mt-[10px]">
+                {(artists ?? []).map((item, i) => (
+                  <ArtistRow key={item.id ?? i} item={item} />
+                ))}
+                {(artists ?? []).length === 0 && (
+                  <p className="text-[var(--color-text-muted)]">
+                    Scrobble more tracks to unlock personalised recommendations.
+                  </p>
+                )}
+              </div>
+            )}
+          </Tab>
+
+          <Tab
+            title="Albums"
+            overrides={{ Tab: { style: TAB_STYLE } }}
+          >
+            {albumsLoading ? (
+              <ListSkeleton />
+            ) : (
+              <div className="mt-[10px]">
+                {(albums ?? []).map((item, i) => (
+                  <AlbumRow key={item.id ?? i} item={item} />
+                ))}
+                {(albums ?? []).length === 0 && (
+                  <p className="text-[var(--color-text-muted)]">
+                    Scrobble more tracks to unlock personalised recommendations.
+                  </p>
+                )}
+              </div>
+            )}
+          </Tab>
+        </Tabs>
+      </div>
+    </Main>
+  );
+}
+
+export default Recommendations;

--- a/apps/web/src/pages/recommendations/index.tsx
+++ b/apps/web/src/pages/recommendations/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Recommendations";

--- a/apps/web/src/routes/recommendations.tsx
+++ b/apps/web/src/routes/recommendations.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import RecommendationsPage from "../pages/recommendations";
+
+export const Route = createFileRoute("/recommendations")({
+  component: RecommendationsPage,
+});


### PR DESCRIPTION
Personalised track recommendations scored by neighbour similarity × recency-decayed play count × loved-track boost (5×), with a 15% serendipity pool from 1-hop artist expansion. Defined in pkl, generated via pkl:gen + lexgen.