### PR TITLE
fix(import): avoid RangeError when importing large CSV files

### DIFF
--- a/apps/api/src/import/app.ts
+++ b/apps/api/src/import/app.ts
@@ -231,8 +231,14 @@ async function runImport(
       .map((t) => t.timestamp ?? 0)
       .filter((t) => t > 0);
     if (validTimestamps.length > 0) {
-      const minTs = new Date(Math.min(...validTimestamps) * 1000);
-      const maxTs = new Date(Math.max(...validTimestamps) * 1000);
+      // Math.min(...arr) passes every element as a call argument and throws
+      // RangeError on large imports (a 20-year Last.fm history is ~500k rows).
+      const minTs = new Date(
+        validTimestamps.reduce((a, b) => Math.min(a, b)) * 1000,
+      );
+      const maxTs = new Date(
+        validTimestamps.reduce((a, b) => Math.max(a, b)) * 1000,
+      );
 
       const existing = await ctx.db
         .select({ timestamp: scrobbles.timestamp })
@@ -460,9 +466,14 @@ app.post("/upload", async (c) => {
   // Fire-and-forget background processing
   runImport(job.id, tracks, user.did).catch((err) => {
     consola.error(`[import] Unhandled error in job ${job.id}:`, err);
+    const msg = err instanceof Error ? err.message : String(err);
     ctx.db
       .update(importJobs)
-      .set({ status: "failed", updatedAt: new Date() })
+      .set({
+        status: "failed",
+        errors: JSON.stringify([`Import crashed: ${msg}`]),
+        updatedAt: new Date(),
+      })
       .where(eq(importJobs.id, job.id))
       .catch(consola.error);
   });


### PR DESCRIPTION
Importing my full Last.fm history (503,069 scrobbles, ~42MB CSV) via `POST /import/upload` fails ~2 seconds after upload with `status: failed, processed: 0, errors: null`.

Root cause is in `runImport`'s duplicate pre-filter:

```ts
const minTs = new Date(Math.min(...validTimestamps) * 1000);
const maxTs = new Date(Math.max(...validTimestamps) * 1000);
```

`Math.min(...arr)` passes every element as an individual function argument, so with 500k+ elements it throws `RangeError: Maximum call stack size exceeded`. The throw escapes `runImport` and is only caught by the fire-and-forget `.catch()` in the upload handler, which marks the job `failed` without recording anything — that's why `errors` stays `null` and the failure is invisible from the client side.

This PR:

- computes min/max with `reduce` instead of spread
- records the exception message in `errors` when `runImport` throws, so the next person hitting a setup failure gets a clue (happy to split this into a separate PR if you prefer)

Repro (no server needed):

```
node -e 'Math.min(...Array(503069).fill(0))'
# RangeError: Maximum call stack size exceeded
```

503069 is the row count of my actual import. Note: bun's JSC happens to survive 500k spread args (it dies around 1M), so this must be tested with node — which is what prod runs (`prod` script / `FROM node:22`).

End-to-end: `POST /import/upload` with a Last.fm CSV that size → job goes `failed` within seconds, `processed: 0`, `errors: null`. The same file split into smaller chunks imports fine, so it's the pre-filter, not the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
