### PR TITLE
feat(scrobble): temporarily block bot-like scrobble rates per user

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import dns from "node:dns";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { trace } from "@opentelemetry/api";
@@ -8,13 +9,16 @@ import { and, desc, eq, isNotNull, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createAgent } from "lib/agent";
+import {
+  ScrobbleBlockedError,
+  scrobbleBlockedMessage,
+} from "lib/scrobbleGuard";
 import { verifyToken } from "lib/verifyToken";
 import {
   getLovedTracks,
   likeTrack,
   unLikeTrack,
 } from "lovedtracks/lovedtracks.service";
-import dns from "node:dns";
 import { scrobbleTrack } from "nowplaying/nowplaying.service";
 import { rateLimiter } from "ratelimiter";
 import subscribe from "subscribers";
@@ -24,12 +28,12 @@ import handleWebsocket from "websocket/handler";
 import accessTokensApp from "./access-tokens/app";
 import apikeys from "./apikeys/app";
 import bsky from "./bsky/app";
-import storageApp from "./storage/app";
-import uploadsApp from "./uploads/app";
-import importApp from "./import/app";
 import dropbox from "./dropbox/app";
 import googledrive from "./googledrive/app";
+import importApp from "./import/app";
 import { requestCounter, requestDuration } from "./metrics";
+import storageApp from "./storage/app";
+import uploadsApp from "./uploads/app";
 import "./profiling";
 import albumTracks from "./schema/album-tracks";
 import albums from "./schema/albums";
@@ -40,9 +44,9 @@ import tracks from "./schema/tracks";
 import users from "./schema/users";
 import spotify from "./spotify/app";
 import "./tracing";
+import opengraph from "./opengraph/app";
 import usersApp from "./users/app";
 import webscrobbler from "./webscrobbler/app";
-import opengraph from "./opengraph/app";
 
 dns.setDefaultResultOrder("ipv4first");
 
@@ -173,7 +177,24 @@ app.post("/now-playing", async (c) => {
     `[now-playing] agent created for ${chalk.cyan(did)}, calling scrobbleTrack`,
   );
 
-  await scrobbleTrack(ctx, track, agent, user.did);
+  try {
+    await scrobbleTrack(ctx, track, agent, user.did);
+  } catch (err) {
+    if (err instanceof ScrobbleBlockedError) {
+      consola.warn(
+        `[now-playing] blocked suspected bot ${chalk.cyan(did)} — retry after ${err.retryAfter}s`,
+      );
+      c.status(429);
+      c.header("Retry-After", err.retryAfter.toString());
+      return c.json({
+        status: "blocked",
+        error: "scrobble_rate_exceeded",
+        message: scrobbleBlockedMessage(err.retryAfter),
+        retryAfter: err.retryAfter,
+      });
+    }
+    throw err;
+  }
 
   return c.json({ status: "ok" });
 });

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-import { cleanEnv, host, port, str } from "envalid";
+import { cleanEnv, host, num, port, str } from "envalid";
 
 dotenv.config();
 
@@ -56,4 +56,8 @@ export const env = cleanEnv(process.env, {
   TYPESENSE_PORT: port({ default: 8108 }),
   TYPESENSE_PROTOCOL: str({ default: "http", choices: ["http", "https"] }),
   TYPESENSE_API_KEY: str({}),
+  // Bot-scrobble guard (see lib/scrobbleGuard.ts). Set SCROBBLE_ABUSE_MAX=0 to disable.
+  SCROBBLE_ABUSE_WINDOW: num({ default: 1800 }), // rolling window, seconds (30m)
+  SCROBBLE_ABUSE_MAX: num({ default: 25 }), // max accepted scrobbles per window
+  SCROBBLE_ABUSE_BLOCK: num({ default: 3600 }), // temp block duration, seconds (1h)
 });

--- a/apps/api/src/lib/scrobbleGuard.ts
+++ b/apps/api/src/lib/scrobbleGuard.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+import type { Context } from "context";
+import { env } from "lib/env";
+
+// Bot-scrobble guard.
+//
+// Some clients started submitting scrobbles every ~1-2 minutes, sustained.
+// A real listener cannot scrobble *distinct* tracks faster than the tracks
+// physically play (and the ±60s dedup in scrobbleTrack already collapses the
+// repeated now-playing pings for a single song). So a per-user rolling window
+// of *accepted* scrobbles is a clean bot fingerprint: exceeding the threshold
+// means sustaining a cadence no genuine listening session reaches.
+//
+// Tunable via env so thresholds can be adjusted without a code change:
+//   SCROBBLE_ABUSE_WINDOW  rolling window, seconds        (default 1800 = 30m)
+//   SCROBBLE_ABUSE_MAX     max accepted scrobbles/window  (default 25)
+//   SCROBBLE_ABUSE_BLOCK   temp block duration, seconds   (default 3600 = 1h)
+// The default 25 / 30min trips only at a sustained avg < 72s per track for a
+// full half hour — physically impossible for a human (even all-2-minute-song
+// listening is ~15/30min). Set SCROBBLE_ABUSE_MAX=0 to disable the guard.
+const WINDOW_SECONDS = env.SCROBBLE_ABUSE_WINDOW;
+const MAX_IN_WINDOW = env.SCROBBLE_ABUSE_MAX;
+const BLOCK_SECONDS = env.SCROBBLE_ABUSE_BLOCK;
+
+const blockKey = (did: string) => `scrobble:block:${did}`;
+const rateKey = (did: string) => `scrobble:rate:${did}`;
+
+export class ScrobbleBlockedError extends Error {
+  readonly did: string;
+  readonly retryAfter: number;
+  constructor(did: string, retryAfter: number) {
+    super(
+      `Scrobble temporarily blocked for ${did} (retry after ${retryAfter}s)`,
+    );
+    this.name = "ScrobbleBlockedError";
+    this.did = did;
+    this.retryAfter = retryAfter;
+  }
+}
+
+/**
+ * Human-readable explanation returned to a suspected bot on both scrobble
+ * entry points (429 on /now-playing, XRPC error on createScrobble).
+ */
+export function scrobbleBlockedMessage(retryAfterSeconds: number): string {
+  const minutes = Math.max(1, Math.ceil(retryAfterSeconds / 60));
+  return (
+    "Your account has been temporarily blocked from scrobbling because we detected " +
+    "an abnormally high scrobble rate — scrobbles are arriving faster than tracks can " +
+    "physically be played, which is a pattern typical of bots or misconfigured clients. " +
+    "Normal listening never triggers this. To resume, submit one scrobble per track only " +
+    "after it has actually played (roughly half its length or ~4 minutes, as Last.fm does), " +
+    "rather than on a fixed short timer. If you believe this is a mistake, contact " +
+    `support@rocksky.app. You can retry in about ${minutes} minute(s).`
+  );
+}
+
+/**
+ * Reject early if the user is currently under a temporary block. Cheap enough
+ * to call before any DB work so blocked bots don't hit Postgres at all.
+ */
+export async function assertNotScrobbleBlocked(
+  ctx: Context,
+  did: string,
+): Promise<void> {
+  if (MAX_IN_WINDOW <= 0) return; // guard disabled
+  const ttl = await ctx.redis.ttl(blockKey(did));
+  if (ttl > 0) throw new ScrobbleBlockedError(did, ttl);
+}
+
+/**
+ * Record an accepted scrobble in the user's rolling window keyed by scrobble
+ * time. If the user has now exceeded MAX_IN_WINDOW accepted scrobbles inside
+ * WINDOW_SECONDS, place a temporary block and throw ScrobbleBlockedError.
+ *
+ * Call this only for genuinely new scrobbles (i.e. after the dedup check has
+ * passed) so repeated now-playing pings for the same song don't inflate the
+ * count.
+ */
+export async function recordScrobbleAndGuard(
+  ctx: Context,
+  did: string,
+  scrobbleTimeUnix: number,
+): Promise<void> {
+  if (MAX_IN_WINDOW <= 0) return; // guard disabled
+
+  const key = rateKey(did);
+  const nowMs = scrobbleTimeUnix * 1000;
+  const windowStartMs = nowMs - WINDOW_SECONDS * 1000;
+
+  // Atomically: add this scrobble, drop anything older than the window, count
+  // what's left, and keep the key from lingering past the window when idle.
+  const results = await ctx.redis
+    .multi()
+    .zAdd(key, { score: nowMs, value: `${nowMs}:${randomUUID()}` })
+    .zRemRangeByScore(key, 0, windowStartMs)
+    .zCard(key)
+    .expire(key, WINDOW_SECONDS)
+    .exec();
+
+  // zCard is the third command in the pipeline.
+  const count = Number(results?.[2] ?? 0);
+
+  if (count > MAX_IN_WINDOW) {
+    await ctx.redis.set(blockKey(did), "1", { EX: BLOCK_SECONDS });
+    throw new ScrobbleBlockedError(did, BLOCK_SECONDS);
+  }
+}

--- a/apps/api/src/nowplaying/nowplaying.service.ts
+++ b/apps/api/src/nowplaying/nowplaying.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Agent } from "@atproto/api";
 import { TID } from "@atproto/common";
 import chalk from "chalk";
@@ -13,7 +14,10 @@ import { deepSnakeCaseKeys, withFallbackAlbumArt } from "lib";
 import { decrypt } from "lib/crypto";
 import { env } from "lib/env";
 import { bumpAllFeedVersions, bumpScrobblesVersion } from "lib/feedCache";
-import { createHash } from "node:crypto";
+import {
+  assertNotScrobbleBlocked,
+  recordScrobbleAndGuard,
+} from "lib/scrobbleGuard";
 import type { MusicbrainzTrack, Track } from "types/track";
 import albumTracks from "../schema/album-tracks";
 import albums from "../schema/albums";
@@ -80,6 +84,7 @@ function trackLookupOrder(t: {
     ELSE 3
   END`;
 }
+
 import userAlbums from "../schema/user-albums";
 import userArtists from "../schema/user-artists";
 import userTracks from "../schema/user-tracks";
@@ -665,6 +670,10 @@ export async function scrobbleTrack(
   // check if scrobble already exists (user did + timestamp)
   // skipDupCheck=true when called from runImport — the bulk pre-filter already handled dedup
   if (!skipDupCheck) {
+    // Reject up front if this user is currently flagged as a bot. Throws
+    // ScrobbleBlockedError, handled by the callers (429 on /now-playing).
+    await assertNotScrobbleBlocked(ctx, userDid);
+
     const scrobbleTime = dayjs.unix(track.timestamp || dayjs().unix());
     const existingScrobble = await ctx.db
       .select({
@@ -698,6 +707,11 @@ export async function scrobbleTrack(
       );
       return;
     }
+
+    // Genuinely new scrobble — record it in the user's rolling window. Throws
+    // ScrobbleBlockedError (and places a temporary block) if the user is
+    // scrobbling faster than a human physically can.
+    await recordScrobbleAndGuard(ctx, userDid, scrobbleTime.unix());
   }
 
   let existingTrack = await ctx.db

--- a/apps/api/src/xrpc/app/rocksky/scrobble/createScrobble.ts
+++ b/apps/api/src/xrpc/app/rocksky/scrobble/createScrobble.ts
@@ -1,10 +1,15 @@
-import { consola } from "consola";
 import chalk from "chalk";
+import { consola } from "consola";
 import type { Context } from "context";
 import type { Server } from "lexicon";
 import { createAgent } from "lib/agent";
-import { type Track, trackSchema } from "types/track";
+import {
+  assertNotScrobbleBlocked,
+  ScrobbleBlockedError,
+  scrobbleBlockedMessage,
+} from "lib/scrobbleGuard";
 import { scrobbleTrack } from "nowplaying/nowplaying.service";
+import { type Track, trackSchema } from "types/track";
 
 export default function (server: Server, ctx: Context) {
   server.app.rocksky.scrobble.createScrobble({
@@ -26,6 +31,24 @@ export default function (server: Server, ctx: Context) {
 
       const track: Track = parsed.data;
 
+      // Bail out synchronously with a comprehensive 429 if this user is
+      // currently flagged as a suspected bot, so the client gets a real error
+      // instead of a silent no-op.
+      try {
+        await assertNotScrobbleBlocked(ctx, did);
+      } catch (err) {
+        if (err instanceof ScrobbleBlockedError) {
+          consola.warn(
+            `[createScrobble] blocked suspected bot ${chalk.cyan(did)} — retry after ${err.retryAfter}s`,
+          );
+          return {
+            status: 429,
+            message: scrobbleBlockedMessage(err.retryAfter),
+          };
+        }
+        throw err;
+      }
+
       // Fire-and-forget — the client doesn't need to wait for the full
       // scrobble pipeline (ATProto puts, MusicBrainz hydration, etc.)
       createAgent(ctx.oauthClient, did)
@@ -35,9 +58,17 @@ export default function (server: Server, ctx: Context) {
             `[createScrobble] scrobble created for ${chalk.cyan(track.title)}`,
           ),
         )
-        .catch((err) =>
-          consola.error(`[createScrobble] failed for ${chalk.cyan(did)}:`, err),
-        );
+        .catch((err) => {
+          // A guard trip on this scrobble sets the block for the *next* request;
+          // it's expected, not an error worth paging on.
+          if (err instanceof ScrobbleBlockedError) {
+            consola.warn(
+              `[createScrobble] rate guard tripped for ${chalk.cyan(did)} — now blocked ${err.retryAfter}s`,
+            );
+            return;
+          }
+          consola.error(`[createScrobble] failed for ${chalk.cyan(did)}:`, err);
+        });
 
       return { encoding: "application/json" as const, body: {} };
     },


### PR DESCRIPTION
Some accounts started submitting scrobbles every ~1-2 minutes sustained, which no real listener produces. Add a per-user rolling-window guard (Redis) over accepted scrobbles: exceeding the threshold within the window places a temporary block and rejects further scrobbles.

- New lib/scrobbleGuard.ts: rolling window keyed by scrobble time, temp block key with TTL, and a comprehensive human-readable block message.
- Counts only deduped (genuinely new) scrobbles, so repeated now-playing pings for one song don't inflate the rate; import path is exempt.
- POST /now-playing returns 429 + Retry-After; createScrobble XRPC returns a 429 with the message instead of a silent no-op.
- Tunable via SCROBBLE_ABUSE_WINDOW/MAX/BLOCK env (MAX=0 disables).