### PR TITLE
feat(scrobble): flag sustained round-the-clock bots via offline sweep

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,7 +11,9 @@ import { cors } from "hono/cors";
 import { createAgent } from "lib/agent";
 import {
   ScrobbleBlockedError,
+  ScrobbleBotFlaggedError,
   scrobbleBlockedMessage,
+  scrobbleBotFlaggedMessage,
 } from "lib/scrobbleGuard";
 import { verifyToken } from "lib/verifyToken";
 import {
@@ -180,6 +182,15 @@ app.post("/now-playing", async (c) => {
   try {
     await scrobbleTrack(ctx, track, agent, user.did);
   } catch (err) {
+    if (err instanceof ScrobbleBotFlaggedError) {
+      consola.warn(`[now-playing] rejected bot-flagged account ${chalk.cyan(did)}`);
+      c.status(429);
+      return c.json({
+        status: "blocked",
+        error: "account_flagged_as_bot",
+        message: scrobbleBotFlaggedMessage(),
+      });
+    }
     if (err instanceof ScrobbleBlockedError) {
       consola.warn(
         `[now-playing] blocked suspected bot ${chalk.cyan(did)} — retry after ${err.retryAfter}s`,

--- a/apps/api/src/lib/scrobbleGuard.ts
+++ b/apps/api/src/lib/scrobbleGuard.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import type { Context } from "context";
+import { eq } from "drizzle-orm";
 import { env } from "lib/env";
+import users from "../schema/users";
 
 // Bot-scrobble guard.
 //
@@ -53,6 +55,53 @@ export function scrobbleBlockedMessage(retryAfterSeconds: number): string {
     "rather than on a fixed short timer. If you believe this is a mistake, contact " +
     `support@rocksky.app. You can retry in about ${minutes} minute(s).`
   );
+}
+
+/**
+ * Raised when a user carries a persistent `is_bot` flag in the DB. Unlike the
+ * rolling-window block (which expires), this flag is set by the offline
+ * scrobble-abuse-sweep service and cleared only by an operator. Extends
+ * ScrobbleBlockedError so existing `instanceof ScrobbleBlockedError` handlers at
+ * both scrobble entry points already reject it with a 429.
+ */
+export class ScrobbleBotFlaggedError extends ScrobbleBlockedError {
+  constructor(did: string) {
+    // retryAfter is meaningless for a persistent flag; keep it 0.
+    super(did, 0);
+    this.name = "ScrobbleBotFlaggedError";
+  }
+}
+
+/**
+ * Human-readable explanation returned to a user whose account is flagged as a
+ * bot. Distinct from the rate-limit message because the flag is not time-boxed.
+ */
+export function scrobbleBotFlaggedMessage(): string {
+  return (
+    "Your account has been flagged as a bot and can no longer scrobble. This " +
+    "happens when scrobbles arrive continuously, around the clock, faster than " +
+    "tracks can physically be played — a pattern real listening never produces. " +
+    "If you believe this is a mistake, contact support@rocksky.app to have it reviewed."
+  );
+}
+
+/**
+ * Reject if the user carries the persistent `is_bot` flag. This is the "always
+ * check the flag" enforcement: one indexed lookup on the scrobble path, in
+ * addition to the rolling-window guard below.
+ */
+export async function assertNotBotFlagged(
+  ctx: Context,
+  did: string,
+): Promise<void> {
+  const row = await ctx.db
+    .select({ isBot: users.isBot })
+    .from(users)
+    .where(eq(users.did, did))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (row?.isBot) throw new ScrobbleBotFlaggedError(did);
 }
 
 /**

--- a/apps/api/src/nowplaying/nowplaying.service.ts
+++ b/apps/api/src/nowplaying/nowplaying.service.ts
@@ -15,6 +15,7 @@ import { decrypt } from "lib/crypto";
 import { env } from "lib/env";
 import { bumpAllFeedVersions, bumpScrobblesVersion } from "lib/feedCache";
 import {
+  assertNotBotFlagged,
   assertNotScrobbleBlocked,
   recordScrobbleAndGuard,
 } from "lib/scrobbleGuard";
@@ -670,8 +671,10 @@ export async function scrobbleTrack(
   // check if scrobble already exists (user did + timestamp)
   // skipDupCheck=true when called from runImport — the bulk pre-filter already handled dedup
   if (!skipDupCheck) {
-    // Reject up front if this user is currently flagged as a bot. Throws
-    // ScrobbleBlockedError, handled by the callers (429 on /now-playing).
+    // Reject up front if this user carries the persistent bot flag (set by the
+    // scrobble-abuse-sweep service) or is currently under a temporary rate
+    // block. Both throw a ScrobbleBlockedError, handled by the callers.
+    await assertNotBotFlagged(ctx, userDid);
     await assertNotScrobbleBlocked(ctx, userDid);
 
     const scrobbleTime = dayjs.unix(track.timestamp || dayjs().unix());

--- a/apps/api/src/xrpc/app/rocksky/scrobble/createScrobble.ts
+++ b/apps/api/src/xrpc/app/rocksky/scrobble/createScrobble.ts
@@ -4,9 +4,12 @@ import type { Context } from "context";
 import type { Server } from "lexicon";
 import { createAgent } from "lib/agent";
 import {
+  assertNotBotFlagged,
   assertNotScrobbleBlocked,
   ScrobbleBlockedError,
+  ScrobbleBotFlaggedError,
   scrobbleBlockedMessage,
+  scrobbleBotFlaggedMessage,
 } from "lib/scrobbleGuard";
 import { scrobbleTrack } from "nowplaying/nowplaying.service";
 import { type Track, trackSchema } from "types/track";
@@ -35,8 +38,15 @@ export default function (server: Server, ctx: Context) {
       // currently flagged as a suspected bot, so the client gets a real error
       // instead of a silent no-op.
       try {
+        await assertNotBotFlagged(ctx, did);
         await assertNotScrobbleBlocked(ctx, did);
       } catch (err) {
+        if (err instanceof ScrobbleBotFlaggedError) {
+          consola.warn(
+            `[createScrobble] rejected bot-flagged account ${chalk.cyan(did)}`,
+          );
+          return { status: 429, message: scrobbleBotFlaggedMessage() };
+        }
         if (err instanceof ScrobbleBlockedError) {
           consola.warn(
             `[createScrobble] blocked suspected bot ${chalk.cyan(did)} — retry after ${err.retryAfter}s`,

--- a/apps/scrobble-abuse-sweep/.env.example
+++ b/apps/scrobble-abuse-sweep/.env.example
@@ -1,0 +1,15 @@
+# Postgres (Xata) connection — same DB the api uses.
+XATA_POSTGRES_URL=postgresql://user:pass@host:5432/db?sslmode=require
+
+# Scheduling
+SWEEP_CRON=0 * * * *      # standard 5-field cron; default: hourly
+SWEEP_ON_BOOT=true        # run once immediately on startup
+SWEEP_DRY_RUN=false       # true = detect + log only, never write the flag
+
+# Detector thresholds (defaults shown; only override to retune)
+SWEEP_LOOKBACK_HOURS=72
+SWEEP_MIN_SCROBBLES=400
+SWEEP_MIN_SPAN_HOURS=24
+SWEEP_MIN_HOURS_OF_DAY=22
+SWEEP_MAX_QUIET_MIN=120
+SWEEP_MAX_P90_GAP_SEC=300

--- a/apps/scrobble-abuse-sweep/README.md
+++ b/apps/scrobble-abuse-sweep/README.md
@@ -1,0 +1,54 @@
+# scrobble-abuse-sweep
+
+A standalone Deno service that periodically scans the scrobble stream for
+sustained, round-the-clock bot behaviour and flags offending accounts in the
+`users` table (`is_bot = true`). The api enforces that flag on every scrobble
+(`apps/api/src/lib/scrobbleGuard.ts`), so flagged accounts are rejected until an
+operator clears the flag.
+
+It complements the inline `scrobbleGuard` in the api: that guard is a real-time
+rolling-window rate limiter (25 scrobbles / 30min), which a _slow_ bot pacing
+itself just under the threshold evades. This sweep catches that slow burn with a
+duration-based signal instead of a rate one.
+
+## The signal
+
+Per user, over a lookback window (default 72h), all five must hold:
+
+| Gate                                      | Default | Meaning                                        |
+| ----------------------------------------- | ------- | ---------------------------------------------- |
+| `span_h >= SWEEP_MIN_SPAN_HOURS`          | 24      | active across at least a full day              |
+| `n >= SWEEP_MIN_SCROBBLES`                | 400     | sustained volume                               |
+| `hrs_of_day >= SWEEP_MIN_HOURS_OF_DAY`    | 22      | active in nearly every hour of the day         |
+| `longest_quiet_min < SWEEP_MAX_QUIET_MIN` | 120     | **never takes a sleep-length break**           |
+| `p90_gap < SWEEP_MAX_P90_GAP_SEC`         | 300     | 90% of scrobbles land within 5min of the prior |
+
+The defining gate is `longest_quiet_min`: a real listener — even a heavy one who
+runs music all day — always has at least one multi-hour silent stretch (sleep).
+When first calibrated against the live user base, the nearest genuine listener
+sat at a longest-quiet of ~743min against the 120min cutoff — a ~6x margin — so
+no human is caught.
+
+## Run
+
+```sh
+deno task start        # cron loop (prod runs this under: doppler run -- deno task start)
+deno task dev          # cron loop with --watch
+deno task sweep:once   # single pass, then exit (set SWEEP_DRY_RUN=true to preview)
+```
+
+`Deno.cron` requires `--unstable-cron`, already wired into the `start`/`dev`
+tasks.
+
+## Safe rollout
+
+Set `SWEEP_DRY_RUN=true` first. The sweep then logs exactly which accounts it
+_would_ flag without writing anything — verify the list is all bots before
+letting it enforce. Retune via the `SWEEP_*` env vars; no code change needed.
+
+## Clearing a false positive
+
+```sql
+UPDATE users SET is_bot = false, bot_flagged_at = NULL, bot_reason = NULL
+WHERE handle = '<handle>';
+```

--- a/apps/scrobble-abuse-sweep/deno.json
+++ b/apps/scrobble-abuse-sweep/deno.json
@@ -1,0 +1,16 @@
+{
+  "tasks": {
+    "start": "deno run --unstable-cron --env-file=.env -A main.ts",
+    "dev": "deno run --unstable-cron --env-file=.env -A --watch main.ts",
+    "sweep:once": "deno run --env-file=.env -A src/cli.ts",
+    "db:generate": "deno run -A npm:drizzle-kit generate",
+    "db:migrate": "deno run -A npm:drizzle-kit migrate"
+  },
+  "imports": {
+    "consola": "npm:consola@^3.4.2",
+    "drizzle-kit": "npm:drizzle-kit@^0.31.8",
+    "drizzle-orm": "npm:drizzle-orm@^0.45.1",
+    "envalid": "npm:envalid@^8.1.1",
+    "pg": "npm:pg@^8.16.3"
+  }
+}

--- a/apps/scrobble-abuse-sweep/deno.lock
+++ b/apps/scrobble-abuse-sweep/deno.lock
@@ -1,0 +1,641 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:consola@^3.4.2": "3.4.2",
+    "npm:drizzle-kit@~0.31.8": "0.31.10",
+    "npm:drizzle-orm@~0.45.1": "0.45.2_pg@8.22.0",
+    "npm:envalid@^8.1.1": "8.2.0",
+    "npm:pg@^8.16.3": "8.22.0"
+  },
+  "npm": {
+    "@drizzle-team/brocli@0.10.2": {
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="
+    },
+    "@esbuild-kit/core-utils@3.3.2": {
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "dependencies": [
+        "esbuild@0.18.20",
+        "source-map-support"
+      ],
+      "deprecated": true
+    },
+    "@esbuild-kit/esm-loader@2.6.5": {
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "dependencies": [
+        "@esbuild-kit/core-utils",
+        "get-tsconfig"
+      ],
+      "deprecated": true
+    },
+    "@esbuild/aix-ppc64@0.25.12": {
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/aix-ppc64@0.28.1": {
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.18.20": {
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm64@0.25.12": {
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm64@0.28.1": {
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.18.20": {
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-arm@0.25.12": {
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-arm@0.28.1": {
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.18.20": {
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/android-x64@0.25.12": {
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/android-x64@0.28.1": {
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.18.20": {
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-arm64@0.25.12": {
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-arm64@0.28.1": {
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.18.20": {
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-x64@0.25.12": {
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-x64@0.28.1": {
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.18.20": {
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-arm64@0.25.12": {
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-arm64@0.28.1": {
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.18.20": {
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-x64@0.25.12": {
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-x64@0.28.1": {
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.18.20": {
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm64@0.25.12": {
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm64@0.28.1": {
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.18.20": {
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-arm@0.25.12": {
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-arm@0.28.1": {
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.18.20": {
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-ia32@0.25.12": {
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-ia32@0.28.1": {
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.18.20": {
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-loong64@0.25.12": {
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-loong64@0.28.1": {
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.18.20": {
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-mips64el@0.25.12": {
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-mips64el@0.28.1": {
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.18.20": {
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-ppc64@0.25.12": {
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-ppc64@0.28.1": {
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.18.20": {
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-riscv64@0.25.12": {
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-riscv64@0.28.1": {
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.18.20": {
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-s390x@0.25.12": {
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-s390x@0.28.1": {
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.18.20": {
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-x64@0.25.12": {
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-x64@0.28.1": {
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.25.12": {
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-arm64@0.28.1": {
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.18.20": {
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-x64@0.25.12": {
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-x64@0.28.1": {
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.25.12": {
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-arm64@0.28.1": {
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.18.20": {
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-x64@0.25.12": {
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-x64@0.28.1": {
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openharmony-arm64@0.25.12": {
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openharmony-arm64@0.28.1": {
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/sunos-x64@0.18.20": {
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.25.12": {
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.28.1": {
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.18.20": {
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-arm64@0.25.12": {
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-arm64@0.28.1": {
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.18.20": {
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-ia32@0.25.12": {
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-ia32@0.28.1": {
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.18.20": {
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-x64@0.25.12": {
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-x64@0.28.1": {
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "buffer-from@1.1.2": {
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "consola@3.4.2": {
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
+    },
+    "drizzle-kit@0.31.10": {
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dependencies": [
+        "@drizzle-team/brocli",
+        "@esbuild-kit/esm-loader",
+        "esbuild@0.25.12",
+        "tsx"
+      ],
+      "bin": true
+    },
+    "drizzle-orm@0.45.2_pg@8.22.0": {
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "dependencies": [
+        "pg"
+      ],
+      "optionalPeers": [
+        "pg"
+      ]
+    },
+    "envalid@8.2.0": {
+      "integrity": "sha512-CkPvea95dwMYE1wnKX5mQXkOpiMs9O+ncv8NqZy+gW7FuzpUp06KTdUHb18xFG8CqQHmfmRqGLF5DuGaBWNrSw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "esbuild@0.18.20": {
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "optionalDependencies": [
+        "@esbuild/android-arm@0.18.20",
+        "@esbuild/android-arm64@0.18.20",
+        "@esbuild/android-x64@0.18.20",
+        "@esbuild/darwin-arm64@0.18.20",
+        "@esbuild/darwin-x64@0.18.20",
+        "@esbuild/freebsd-arm64@0.18.20",
+        "@esbuild/freebsd-x64@0.18.20",
+        "@esbuild/linux-arm@0.18.20",
+        "@esbuild/linux-arm64@0.18.20",
+        "@esbuild/linux-ia32@0.18.20",
+        "@esbuild/linux-loong64@0.18.20",
+        "@esbuild/linux-mips64el@0.18.20",
+        "@esbuild/linux-ppc64@0.18.20",
+        "@esbuild/linux-riscv64@0.18.20",
+        "@esbuild/linux-s390x@0.18.20",
+        "@esbuild/linux-x64@0.18.20",
+        "@esbuild/netbsd-x64@0.18.20",
+        "@esbuild/openbsd-x64@0.18.20",
+        "@esbuild/sunos-x64@0.18.20",
+        "@esbuild/win32-arm64@0.18.20",
+        "@esbuild/win32-ia32@0.18.20",
+        "@esbuild/win32-x64@0.18.20"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "esbuild@0.25.12": {
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64@0.25.12",
+        "@esbuild/android-arm@0.25.12",
+        "@esbuild/android-arm64@0.25.12",
+        "@esbuild/android-x64@0.25.12",
+        "@esbuild/darwin-arm64@0.25.12",
+        "@esbuild/darwin-x64@0.25.12",
+        "@esbuild/freebsd-arm64@0.25.12",
+        "@esbuild/freebsd-x64@0.25.12",
+        "@esbuild/linux-arm@0.25.12",
+        "@esbuild/linux-arm64@0.25.12",
+        "@esbuild/linux-ia32@0.25.12",
+        "@esbuild/linux-loong64@0.25.12",
+        "@esbuild/linux-mips64el@0.25.12",
+        "@esbuild/linux-ppc64@0.25.12",
+        "@esbuild/linux-riscv64@0.25.12",
+        "@esbuild/linux-s390x@0.25.12",
+        "@esbuild/linux-x64@0.25.12",
+        "@esbuild/netbsd-arm64@0.25.12",
+        "@esbuild/netbsd-x64@0.25.12",
+        "@esbuild/openbsd-arm64@0.25.12",
+        "@esbuild/openbsd-x64@0.25.12",
+        "@esbuild/openharmony-arm64@0.25.12",
+        "@esbuild/sunos-x64@0.25.12",
+        "@esbuild/win32-arm64@0.25.12",
+        "@esbuild/win32-ia32@0.25.12",
+        "@esbuild/win32-x64@0.25.12"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "esbuild@0.28.1": {
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64@0.28.1",
+        "@esbuild/android-arm@0.28.1",
+        "@esbuild/android-arm64@0.28.1",
+        "@esbuild/android-x64@0.28.1",
+        "@esbuild/darwin-arm64@0.28.1",
+        "@esbuild/darwin-x64@0.28.1",
+        "@esbuild/freebsd-arm64@0.28.1",
+        "@esbuild/freebsd-x64@0.28.1",
+        "@esbuild/linux-arm@0.28.1",
+        "@esbuild/linux-arm64@0.28.1",
+        "@esbuild/linux-ia32@0.28.1",
+        "@esbuild/linux-loong64@0.28.1",
+        "@esbuild/linux-mips64el@0.28.1",
+        "@esbuild/linux-ppc64@0.28.1",
+        "@esbuild/linux-riscv64@0.28.1",
+        "@esbuild/linux-s390x@0.28.1",
+        "@esbuild/linux-x64@0.28.1",
+        "@esbuild/netbsd-arm64@0.28.1",
+        "@esbuild/netbsd-x64@0.28.1",
+        "@esbuild/openbsd-arm64@0.28.1",
+        "@esbuild/openbsd-x64@0.28.1",
+        "@esbuild/openharmony-arm64@0.28.1",
+        "@esbuild/sunos-x64@0.28.1",
+        "@esbuild/win32-arm64@0.28.1",
+        "@esbuild/win32-ia32@0.28.1",
+        "@esbuild/win32-x64@0.28.1"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "fsevents@2.3.3": {
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
+    },
+    "get-tsconfig@4.14.0": {
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dependencies": [
+        "resolve-pkg-maps"
+      ]
+    },
+    "pg-cloudflare@1.4.0": {
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="
+    },
+    "pg-connection-string@2.14.0": {
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="
+    },
+    "pg-int8@1.0.1": {
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool@3.14.0_pg@8.22.0": {
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dependencies": [
+        "pg"
+      ]
+    },
+    "pg-protocol@1.15.0": {
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="
+    },
+    "pg-types@2.2.0": {
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": [
+        "pg-int8",
+        "postgres-array",
+        "postgres-bytea",
+        "postgres-date",
+        "postgres-interval"
+      ]
+    },
+    "pg@8.22.0": {
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dependencies": [
+        "pg-connection-string",
+        "pg-pool",
+        "pg-protocol",
+        "pg-types",
+        "pgpass"
+      ],
+      "optionalDependencies": [
+        "pg-cloudflare"
+      ]
+    },
+    "pgpass@1.0.5": {
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": [
+        "split2"
+      ]
+    },
+    "postgres-array@2.0.0": {
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea@1.0.1": {
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="
+    },
+    "postgres-date@1.0.7": {
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval@1.2.0": {
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": [
+        "xtend"
+      ]
+    },
+    "resolve-pkg-maps@1.0.0": {
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
+    },
+    "source-map-support@0.5.21": {
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dependencies": [
+        "buffer-from",
+        "source-map"
+      ]
+    },
+    "source-map@0.6.1": {
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "split2@4.2.0": {
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tsx@4.23.1": {
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dependencies": [
+        "esbuild@0.28.1"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
+    "xtend@4.0.2": {
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:consola@^3.4.2",
+      "npm:drizzle-kit@~0.31.8",
+      "npm:drizzle-orm@~0.45.1",
+      "npm:envalid@^8.1.1",
+      "npm:pg@^8.16.3"
+    ]
+  }
+}

--- a/apps/scrobble-abuse-sweep/drizzle.config.ts
+++ b/apps/scrobble-abuse-sweep/drizzle.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/schema",
+  dbCredentials: {
+    url: Deno.env.get("XATA_POSTGRES_URL")!,
+  },
+});

--- a/apps/scrobble-abuse-sweep/main.ts
+++ b/apps/scrobble-abuse-sweep/main.ts
@@ -1,0 +1,22 @@
+import { consola } from "consola";
+import { runSweep } from "./src/sweep.ts";
+import { env } from "./src/utils/env.ts";
+
+consola.info(
+  `[scrobble-abuse-sweep] starting — cron="${env.SWEEP_CRON}" ` +
+    `dryRun=${env.SWEEP_DRY_RUN} lookback=${env.SWEEP_LOOKBACK_HOURS}h`,
+);
+
+// Native Deno scheduler (requires --unstable-cron). Overlapping runs are
+// suppressed by the runtime, so a slow sweep never stacks on the next tick.
+Deno.cron("scrobble-abuse-sweep", env.SWEEP_CRON, async () => {
+  try {
+    await runSweep();
+  } catch (err) {
+    consola.error("[sweep] run failed:", err);
+  }
+});
+
+if (env.SWEEP_ON_BOOT) {
+  runSweep().catch((err) => consola.error("[sweep] boot run failed:", err));
+}

--- a/apps/scrobble-abuse-sweep/src/cli.ts
+++ b/apps/scrobble-abuse-sweep/src/cli.ts
@@ -1,0 +1,12 @@
+// One-shot sweep for manual runs / ops verification: `deno task sweep:once`.
+// Honours the same env (set SWEEP_DRY_RUN=true to preview without writing).
+import { consola } from "consola";
+import { runSweep } from "./sweep.ts";
+
+try {
+  await runSweep();
+  Deno.exit(0);
+} catch (err) {
+  consola.error("[sweep] failed:", err);
+  Deno.exit(1);
+}

--- a/apps/scrobble-abuse-sweep/src/drizzle.ts
+++ b/apps/scrobble-abuse-sweep/src/drizzle.ts
@@ -1,0 +1,17 @@
+import { consola } from "consola";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import { env } from "./utils/env.ts";
+
+const pool = new pg.Pool({
+  connectionString: env.XATA_POSTGRES_URL,
+  max: 5,
+});
+
+pool.on("error", (err: Error) => {
+  consola.error("[db] idle pg client error:", err.message);
+});
+
+const db = drizzle(pool);
+
+export default { db };

--- a/apps/scrobble-abuse-sweep/src/schema/mod.ts
+++ b/apps/scrobble-abuse-sweep/src/schema/mod.ts
@@ -1,0 +1,7 @@
+import scrobbles from "./scrobbles.ts";
+import users from "./users.ts";
+
+export default {
+  scrobbles,
+  users,
+};

--- a/apps/scrobble-abuse-sweep/src/schema/scrobbles.ts
+++ b/apps/scrobble-abuse-sweep/src/schema/scrobbles.ts
@@ -1,0 +1,23 @@
+import { type InferSelectModel, sql } from "drizzle-orm";
+import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+// Read-only view of the scrobbles table — just the columns the detector reads.
+// FK references are intentionally omitted so this app stays self-contained.
+const scrobbles = pgTable("scrobbles", {
+  id: text("xata_id")
+    .primaryKey()
+    .default(sql`xata_id()`),
+  userId: text("user_id"),
+  trackId: text("track_id"),
+  albumId: text("album_id"),
+  artistId: text("artist_id"),
+  uri: text("uri"),
+  createdAt: timestamp("xata_createdat").defaultNow().notNull(),
+  updatedAt: timestamp("xata_updatedat").defaultNow().notNull(),
+  xataVersion: integer("xata_version"),
+  timestamp: timestamp("timestamp").defaultNow().notNull(),
+});
+
+export type SelectScrobble = InferSelectModel<typeof scrobbles>;
+
+export default scrobbles;

--- a/apps/scrobble-abuse-sweep/src/schema/users.ts
+++ b/apps/scrobble-abuse-sweep/src/schema/users.ts
@@ -8,13 +8,15 @@ import {
 } from "drizzle-orm/pg-core";
 
 const users = pgTable("users", {
-  id: text("xata_id").primaryKey().default(sql`xata_id()`),
+  id: text("xata_id")
+    .primaryKey()
+    .default(sql`xata_id()`),
   did: text("did").unique().notNull(),
   displayName: text("display_name"),
   handle: text("handle").unique().notNull(),
   avatar: text("avatar").notNull(),
-  // Persistent bot flag, written by the scrobble-abuse-sweep service and
-  // enforced on every scrobble (see lib/scrobbleGuard.ts#assertNotBotFlagged).
+  // Persistent bot flag. Written by this sweep and enforced on every scrobble by
+  // the api (lib/scrobbleGuard.ts#assertNotBotFlagged).
   isBot: boolean("is_bot").notNull().default(false),
   botFlaggedAt: timestamp("bot_flagged_at", { withTimezone: true }),
   botReason: text("bot_reason"),
@@ -24,6 +26,5 @@ const users = pgTable("users", {
 });
 
 export type SelectUser = InferSelectModel<typeof users>;
-export type InsertUser = InferSelectModel<typeof users>;
 
 export default users;

--- a/apps/scrobble-abuse-sweep/src/sweep.ts
+++ b/apps/scrobble-abuse-sweep/src/sweep.ts
@@ -1,0 +1,134 @@
+import { consola } from "consola";
+import { sql } from "drizzle-orm";
+import drizzle from "./drizzle.ts";
+import { env } from "./utils/env.ts";
+
+const { db } = drizzle;
+
+/**
+ * A user whose recent scrobble stream matches the sustained round-the-clock
+ * looping pattern of a bot — high volume, tight cadence, active in nearly every
+ * hour of the day, and never a sleep-length quiet break.
+ */
+export type BotCandidate = {
+  did: string;
+  handle: string;
+  n: number;
+  distinct_tracks: number;
+  p90_gap: number;
+  longest_quiet_min: number;
+  hrs_of_day: number;
+  span_h: number;
+};
+
+/**
+ * Score every user active in the lookback window on five independent signals and
+ * return those matching all of them. Users already flagged (is_bot=true) are
+ * excluded so each run only surfaces *new* offenders.
+ *
+ * The defining signal is longest_quiet_min: a real listener — even a heavy one
+ * running music all day — always has at least one multi-hour silent stretch
+ * (sleep). A stream that never goes quiet for >2h while sustaining 400+ scrobbles
+ * across a full day, in nearly every hour, at a <5min p90 cadence, is not human.
+ */
+export async function detectBots(): Promise<BotCandidate[]> {
+  const result = await db.execute(sql`
+    WITH recent AS (
+      SELECT
+        user_id,
+        track_id,
+        "timestamp",
+        extract(epoch FROM ("timestamp" - lag("timestamp")
+          OVER (PARTITION BY user_id ORDER BY "timestamp"))) AS gap
+      FROM scrobbles
+      WHERE "timestamp" > now() - (${env.SWEEP_LOOKBACK_HOURS} * interval '1 hour')
+    ),
+    agg AS (
+      SELECT
+        user_id,
+        count(*) AS n,
+        count(DISTINCT track_id) AS distinct_tracks,
+        percentile_cont(0.90) WITHIN GROUP (ORDER BY gap) AS p90_gap,
+        max(gap) / 60.0 AS longest_quiet_min,
+        count(DISTINCT extract(hour FROM "timestamp")) AS hrs_of_day,
+        extract(epoch FROM (max("timestamp") - min("timestamp"))) / 3600.0 AS span_h
+      FROM recent
+      GROUP BY user_id
+    )
+    SELECT
+      u.did,
+      u.handle,
+      a.n::int AS n,
+      a.distinct_tracks::int AS distinct_tracks,
+      round(a.p90_gap)::int AS p90_gap,
+      round(a.longest_quiet_min)::int AS longest_quiet_min,
+      a.hrs_of_day::int AS hrs_of_day,
+      round(a.span_h::numeric, 1)::float8 AS span_h
+    FROM agg a
+    JOIN users u ON u.xata_id = a.user_id
+    WHERE a.span_h >= ${env.SWEEP_MIN_SPAN_HOURS}
+      AND a.n >= ${env.SWEEP_MIN_SCROBBLES}
+      AND a.hrs_of_day >= ${env.SWEEP_MIN_HOURS_OF_DAY}
+      AND a.longest_quiet_min < ${env.SWEEP_MAX_QUIET_MIN}
+      AND a.p90_gap < ${env.SWEEP_MAX_P90_GAP_SEC}
+      AND u.is_bot = false
+    ORDER BY a.longest_quiet_min ASC
+  `);
+
+  return result.rows as unknown as BotCandidate[];
+}
+
+function reasonFor(c: BotCandidate): string {
+  return (
+    `auto-flagged by scrobble-abuse-sweep: ${c.n} scrobbles / ` +
+    `${env.SWEEP_LOOKBACK_HOURS}h across ${c.distinct_tracks} tracks, ` +
+    `p90 gap ${c.p90_gap}s, longest quiet ${c.longest_quiet_min}min, ` +
+    `active ${c.hrs_of_day}/24h of day`
+  );
+}
+
+/**
+ * Persist the flag. Idempotent and race-safe: the `is_bot = false` guard means a
+ * user already flagged (by a concurrent run or an earlier pass) is left as-is, so
+ * bot_flagged_at keeps its original value.
+ */
+export async function flagBots(candidates: BotCandidate[]): Promise<number> {
+  let flagged = 0;
+  for (const c of candidates) {
+    const res = await db.execute(sql`
+      UPDATE users
+      SET is_bot = true, bot_flagged_at = now(), bot_reason = ${reasonFor(c)}
+      WHERE did = ${c.did} AND is_bot = false
+    `);
+    flagged += res.rowCount ?? 0;
+  }
+  return flagged;
+}
+
+/** One full detection pass: detect, log the evidence, then flag (unless dry-run). */
+export async function runSweep(): Promise<void> {
+  const candidates = await detectBots();
+
+  if (candidates.length === 0) {
+    consola.info("[sweep] no new bot-like accounts detected");
+    return;
+  }
+
+  consola.warn(`[sweep] ${candidates.length} candidate(s):`);
+  for (const c of candidates) {
+    consola.warn(
+      `  ${c.handle} (${c.did}) — n=${c.n} tracks=${c.distinct_tracks} ` +
+        `p90=${c.p90_gap}s quiet=${c.longest_quiet_min}min hrs=${c.hrs_of_day}/24`,
+    );
+  }
+
+  if (env.SWEEP_DRY_RUN) {
+    consola.info(
+      `[sweep] DRY_RUN — would flag ${candidates.length} account(s); no writes made`,
+    );
+    return;
+  }
+
+  const flagged = await flagBots(candidates);
+  consola.success(`[sweep] flagged ${flagged} account(s) as bot`);
+}

--- a/apps/scrobble-abuse-sweep/src/utils/env.ts
+++ b/apps/scrobble-abuse-sweep/src/utils/env.ts
@@ -1,0 +1,28 @@
+import { bool, cleanEnv, num, str } from "envalid";
+import process from "node:process";
+
+export const env = cleanEnv(process.env, {
+  XATA_POSTGRES_URL: str({
+    devDefault:
+      "postgresql://postgres:mysecretpassword@localhost:5433/rocksky?sslmode=disable",
+  }),
+
+  // Cron schedule for the sweep. Standard 5-field cron; default: top of every hour.
+  SWEEP_CRON: str({ default: "0 * * * *" }),
+  // Run one sweep immediately on boot, in addition to the cron schedule.
+  SWEEP_ON_BOOT: bool({ default: true }),
+  // Detect but don't write the flag — logs what it *would* flag. Use to dry-run
+  // threshold changes against production before letting them block anyone.
+  SWEEP_DRY_RUN: bool({ default: false }),
+
+  // --- Detector thresholds ---------------------------------------------------
+  // Validated against the live user base: these five gates flagged exactly the
+  // sustained round-the-clock loopers and left every real listener untouched
+  // (nearest human sat at longest_quiet ~= 743min vs the 120min cutoff — 6x margin).
+  SWEEP_LOOKBACK_HOURS: num({ default: 72 }), // window analysed each run
+  SWEEP_MIN_SCROBBLES: num({ default: 400 }), // sustained volume over the window
+  SWEEP_MIN_SPAN_HOURS: num({ default: 24 }), // active across at least a full day
+  SWEEP_MIN_HOURS_OF_DAY: num({ default: 22 }), // active in nearly every hour of day
+  SWEEP_MAX_QUIET_MIN: num({ default: 120 }), // never takes a sleep-length break
+  SWEEP_MAX_P90_GAP_SEC: num({ default: 300 }), // 90% of scrobbles within 5min of prior
+});

--- a/systemd/rocksky-scrobble-abuse-sweep.service
+++ b/systemd/rocksky-scrobble-abuse-sweep.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Rocksky Scrobble Abuse Sweep Service
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/github/rocksky/apps/scrobble-abuse-sweep
+ExecStart=/bin/bash -ic 'exec doppler run -- deno task start'
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=rocksky-scrobble-abuse-sweep
+
+# Environment
+Environment=HOME=/root
+Environment=USER=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The inline scrobbleGuard is a real-time rate limiter (25/30min); a bot pacing itself just under that threshold evades it while scrobbling continuously for days. Catch that slow burn with a duration-based signal instead of a rate one.

New apps/scrobble-abuse-sweep: a standalone Deno service (Drizzle + native Deno.cron) that scores each active user over a lookback window on five signals — sustained volume, full-day span, active in nearly every hour, tight p90 cadence, and crucially never a sleep-length quiet break — and flags matches in users.is_bot. Calibrated against the live user base: the nearest genuine listener sits ~6x clear of the longest-quiet cutoff, so no human is caught. Idempotent, env-tunable, with a SWEEP_DRY_RUN preview mode and a sweep:once CLI.

The api now always enforces the flag: assertNotBotFlagged() runs on both scrobble entry points and rejects flagged accounts with a 429 and a dedicated ScrobbleBotFlaggedError/message. Adds is_bot/bot_flagged_at/bot_reason to the users schema (column already applied) and a systemd unit for production.