### PR TITLE
feat(scrobble): add burst detector for fresh dense-loop bots

### DIFF
--- a/apps/scrobble-abuse-sweep/.env.example
+++ b/apps/scrobble-abuse-sweep/.env.example
@@ -6,10 +6,16 @@ SWEEP_CRON=0 * * * *      # standard 5-field cron; default: hourly
 SWEEP_ON_BOOT=true        # run once immediately on startup
 SWEEP_DRY_RUN=false       # true = detect + log only, never write the flag
 
-# Detector thresholds (defaults shown; only override to retune)
+# Round-the-clock detector thresholds (defaults shown; only override to retune)
 SWEEP_LOOKBACK_HOURS=72
 SWEEP_MIN_SCROBBLES=400
 SWEEP_MIN_SPAN_HOURS=24
 SWEEP_MIN_HOURS_OF_DAY=22
 SWEEP_MAX_QUIET_MIN=120
 SWEEP_MAX_P90_GAP_SEC=300
+
+# Burst detector thresholds (catches fresh dense bursts before a full day accrues)
+SWEEP_BURST_MIN_SCROBBLES=150
+SWEEP_BURST_MAX_QUIET_MIN=120
+SWEEP_BURST_FAST_FRACTION=0.5
+SWEEP_BURST_MIN_FAST_PCT=30

--- a/apps/scrobble-abuse-sweep/README.md
+++ b/apps/scrobble-abuse-sweep/README.md
@@ -11,9 +11,15 @@ rolling-window rate limiter (25 scrobbles / 30min), which a _slow_ bot pacing
 itself just under the threshold evades. This sweep catches that slow burn with a
 duration-based signal instead of a rate one.
 
-## The signal
+## The signals
 
-Per user, over a lookback window (default 72h), all five must hold:
+Two detectors run each pass over the same lookback window (default 72h). A user
+matching either is flagged; one matching both is reported once (round-the-clock
+wins). Candidates are de-duplicated by DID.
+
+### 1. Round-the-clock
+
+A sustained looper active every hour, for days, that never sleeps. All five hold:
 
 | Gate                                      | Default | Meaning                                        |
 | ----------------------------------------- | ------- | ---------------------------------------------- |
@@ -28,6 +34,27 @@ runs music all day — always has at least one multi-hour silent stretch (sleep)
 When first calibrated against the live user base, the nearest genuine listener
 sat at a longest-quiet of ~743min against the 120min cutoff — a ~6x margin — so
 no human is caught.
+
+### 2. Burst
+
+The round-the-clock detector needs a full day of history, so a **fresh account
+running a dense burst** slips past it until it has polluted a day of stats. The
+burst detector catches it earlier with a physical-impossibility signal: a
+scrobble only registers after you've actually played most of a track, so a
+stream that logs tracks _faster than they can play_ is not a human listening.
+
+| Gate                                              | Default | Meaning                                                             |
+| ------------------------------------------------- | ------- | ------------------------------------------------------------------- |
+| `n >= SWEEP_BURST_MIN_SCROBBLES`                  | 150     | sustained volume                                                    |
+| `longest_quiet_min < SWEEP_BURST_MAX_QUIET_MIN`   | 120     | **never takes a sleep-length break**                                |
+| `fast_pct >= SWEEP_BURST_MIN_FAST_PCT`            | 30      | ≥30% of scrobbles logged within `FAST_FRACTION` of the track length |
+
+`fast_pct` is the share of scrobbles whose gap since the previous one is under
+`SWEEP_BURST_FAST_FRACTION` (default `0.5`) of the track's own duration — i.e.
+the track was logged after less than half of it could have played. Calibrated
+against the live user base over 72h, this flagged four burst bots
+(impossibly-fast share 34–70%) and left every human clear — the heaviest genuine
+listener sat at 18%, comfortably below the 30% cutoff.
 
 ## Run
 

--- a/apps/scrobble-abuse-sweep/src/sweep.ts
+++ b/apps/scrobble-abuse-sweep/src/sweep.ts
@@ -6,32 +6,35 @@ import { env } from "./utils/env.ts";
 const { db } = drizzle;
 
 /**
- * A user whose recent scrobble stream matches the sustained round-the-clock
- * looping pattern of a bot — high volume, tight cadence, active in nearly every
- * hour of the day, and never a sleep-length quiet break.
+ * A user whose recent scrobble stream matches a known bot pattern. Two
+ * detectors produce candidates:
+ *
+ *  - "round-the-clock": high volume, tight cadence, active in nearly every hour
+ *    of the day, spanning a full day, and never a sleep-length quiet break.
+ *  - "burst": a dense, no-break burst that logs tracks *faster than they can
+ *    physically play* — caught without needing a full day of history.
+ *
+ * `reason` is the human-readable string persisted to `users.bot_reason`;
+ * `evidence` is a compact one-liner for the sweep log.
  */
 export type BotCandidate = {
+  detector: "round-the-clock" | "burst";
   did: string;
   handle: string;
-  n: number;
-  distinct_tracks: number;
-  p90_gap: number;
-  longest_quiet_min: number;
-  hrs_of_day: number;
-  span_h: number;
+  reason: string;
+  evidence: string;
 };
 
 /**
- * Score every user active in the lookback window on five independent signals and
- * return those matching all of them. Users already flagged (is_bot=true) are
- * excluded so each run only surfaces *new* offenders.
+ * Round-the-clock detector. Score every user active in the lookback window on
+ * five independent signals and return those matching all of them.
  *
  * The defining signal is longest_quiet_min: a real listener — even a heavy one
  * running music all day — always has at least one multi-hour silent stretch
  * (sleep). A stream that never goes quiet for >2h while sustaining 400+ scrobbles
  * across a full day, in nearly every hour, at a <5min p90 cadence, is not human.
  */
-export async function detectBots(): Promise<BotCandidate[]> {
+export async function detectRoundTheClockBots(): Promise<BotCandidate[]> {
   const result = await db.execute(sql`
     WITH recent AS (
       SELECT
@@ -75,16 +78,130 @@ export async function detectBots(): Promise<BotCandidate[]> {
     ORDER BY a.longest_quiet_min ASC
   `);
 
-  return result.rows as unknown as BotCandidate[];
+  return (result.rows as Array<Record<string, unknown>>).map((r) => {
+    const c = r as {
+      did: string;
+      handle: string;
+      n: number;
+      distinct_tracks: number;
+      p90_gap: number;
+      longest_quiet_min: number;
+      hrs_of_day: number;
+    };
+    return {
+      detector: "round-the-clock" as const,
+      did: c.did,
+      handle: c.handle,
+      reason:
+        `auto-flagged by scrobble-abuse-sweep (round-the-clock): ${c.n} scrobbles / ` +
+        `${env.SWEEP_LOOKBACK_HOURS}h across ${c.distinct_tracks} tracks, ` +
+        `p90 gap ${c.p90_gap}s, longest quiet ${c.longest_quiet_min}min, ` +
+        `active ${c.hrs_of_day}/24h of day`,
+      evidence:
+        `n=${c.n} tracks=${c.distinct_tracks} p90=${c.p90_gap}s ` +
+        `quiet=${c.longest_quiet_min}min hrs=${c.hrs_of_day}/24`,
+    };
+  });
 }
 
-function reasonFor(c: BotCandidate): string {
-  return (
-    `auto-flagged by scrobble-abuse-sweep: ${c.n} scrobbles / ` +
-    `${env.SWEEP_LOOKBACK_HOURS}h across ${c.distinct_tracks} tracks, ` +
-    `p90 gap ${c.p90_gap}s, longest quiet ${c.longest_quiet_min}min, ` +
-    `active ${c.hrs_of_day}/24h of day`
-  );
+/**
+ * Burst detector. Catches a dense, no-break burst that logs tracks faster than
+ * they can physically play — the signature of a fresh account looping a small
+ * catalogue that hasn't yet accrued the full-day history the round-the-clock
+ * detector requires.
+ *
+ * The defining signal is the *impossibly-fast share*: a genuine scrobble only
+ * registers after most of a track has actually played, so the gap since the
+ * previous scrobble should be at least ~one track length. Counting the fraction
+ * of scrobbles that instead land within `SWEEP_BURST_FAST_FRACTION` of the
+ * track's own duration gives a rate that no real listener sustains — calibration
+ * put the heaviest genuine listener at 18% against the 30% cutoff.
+ */
+export async function detectBurstBots(): Promise<BotCandidate[]> {
+  const result = await db.execute(sql`
+    WITH recent AS (
+      SELECT
+        sc.user_id,
+        sc.track_id,
+        sc."timestamp",
+        t.duration AS dur_ms,
+        extract(epoch FROM (sc."timestamp" - lag(sc."timestamp")
+          OVER (PARTITION BY sc.user_id ORDER BY sc."timestamp"))) AS gap
+      FROM scrobbles sc
+      LEFT JOIN tracks t ON t.xata_id = sc.track_id
+      WHERE sc."timestamp" > now() - (${env.SWEEP_LOOKBACK_HOURS} * interval '1 hour')
+    ),
+    agg AS (
+      SELECT
+        user_id,
+        count(*) AS n,
+        count(DISTINCT track_id) AS distinct_tracks,
+        max(gap) / 60.0 AS longest_quiet_min,
+        count(*) FILTER (WHERE gap IS NOT NULL AND dur_ms IS NOT NULL) AS dur_pairs,
+        count(*) FILTER (
+          WHERE gap < (dur_ms / 1000.0) * ${env.SWEEP_BURST_FAST_FRACTION}
+        ) AS fast_pairs
+      FROM recent
+      GROUP BY user_id
+    )
+    SELECT
+      u.did,
+      u.handle,
+      a.n::int AS n,
+      a.distinct_tracks::int AS distinct_tracks,
+      round(a.longest_quiet_min)::int AS longest_quiet_min,
+      round(100.0 * a.fast_pairs / a.dur_pairs)::int AS fast_pct
+    FROM agg a
+    JOIN users u ON u.xata_id = a.user_id
+    WHERE a.n >= ${env.SWEEP_BURST_MIN_SCROBBLES}
+      AND a.longest_quiet_min < ${env.SWEEP_BURST_MAX_QUIET_MIN}
+      AND a.dur_pairs >= ${env.SWEEP_BURST_MIN_SCROBBLES} / 2
+      AND (100.0 * a.fast_pairs / a.dur_pairs) >= ${env.SWEEP_BURST_MIN_FAST_PCT}
+      AND u.is_bot = false
+    ORDER BY fast_pct DESC
+  `);
+
+  return (result.rows as Array<Record<string, unknown>>).map((r) => {
+    const c = r as {
+      did: string;
+      handle: string;
+      n: number;
+      distinct_tracks: number;
+      longest_quiet_min: number;
+      fast_pct: number;
+    };
+    return {
+      detector: "burst" as const,
+      did: c.did,
+      handle: c.handle,
+      reason:
+        `auto-flagged by scrobble-abuse-sweep (burst): ${c.n} scrobbles / ` +
+        `${env.SWEEP_LOOKBACK_HOURS}h across ${c.distinct_tracks} tracks, ` +
+        `${c.fast_pct}% logged faster than ${env.SWEEP_BURST_FAST_FRACTION}× the ` +
+        `track's own length, longest quiet ${c.longest_quiet_min}min`,
+      evidence:
+        `n=${c.n} tracks=${c.distinct_tracks} fast=${c.fast_pct}% ` +
+        `quiet=${c.longest_quiet_min}min`,
+    };
+  });
+}
+
+/**
+ * Run both detectors and merge their candidates, de-duplicated by DID. A user
+ * matching both is reported once — the round-the-clock reason wins since it is
+ * the stronger, longer-horizon signal.
+ */
+export async function detectBots(): Promise<BotCandidate[]> {
+  const [roundTheClock, burst] = await Promise.all([
+    detectRoundTheClockBots(),
+    detectBurstBots(),
+  ]);
+
+  const byDid = new Map<string, BotCandidate>();
+  for (const c of [...roundTheClock, ...burst]) {
+    if (!byDid.has(c.did)) byDid.set(c.did, c);
+  }
+  return [...byDid.values()];
 }
 
 /**
@@ -97,7 +214,7 @@ export async function flagBots(candidates: BotCandidate[]): Promise<number> {
   for (const c of candidates) {
     const res = await db.execute(sql`
       UPDATE users
-      SET is_bot = true, bot_flagged_at = now(), bot_reason = ${reasonFor(c)}
+      SET is_bot = true, bot_flagged_at = now(), bot_reason = ${c.reason}
       WHERE did = ${c.did} AND is_bot = false
     `);
     flagged += res.rowCount ?? 0;
@@ -116,10 +233,7 @@ export async function runSweep(): Promise<void> {
 
   consola.warn(`[sweep] ${candidates.length} candidate(s):`);
   for (const c of candidates) {
-    consola.warn(
-      `  ${c.handle} (${c.did}) — n=${c.n} tracks=${c.distinct_tracks} ` +
-        `p90=${c.p90_gap}s quiet=${c.longest_quiet_min}min hrs=${c.hrs_of_day}/24`,
-    );
+    consola.warn(`  [${c.detector}] ${c.handle} (${c.did}) — ${c.evidence}`);
   }
 
   if (env.SWEEP_DRY_RUN) {

--- a/apps/scrobble-abuse-sweep/src/utils/env.ts
+++ b/apps/scrobble-abuse-sweep/src/utils/env.ts
@@ -15,7 +15,7 @@ export const env = cleanEnv(process.env, {
   // threshold changes against production before letting them block anyone.
   SWEEP_DRY_RUN: bool({ default: false }),
 
-  // --- Detector thresholds ---------------------------------------------------
+  // --- Round-the-clock detector thresholds ----------------------------------
   // Validated against the live user base: these five gates flagged exactly the
   // sustained round-the-clock loopers and left every real listener untouched
   // (nearest human sat at longest_quiet ~= 743min vs the 120min cutoff — 6x margin).
@@ -25,4 +25,19 @@ export const env = cleanEnv(process.env, {
   SWEEP_MIN_HOURS_OF_DAY: num({ default: 22 }), // active in nearly every hour of day
   SWEEP_MAX_QUIET_MIN: num({ default: 120 }), // never takes a sleep-length break
   SWEEP_MAX_P90_GAP_SEC: num({ default: 300 }), // 90% of scrobbles within 5min of prior
+
+  // --- Burst detector thresholds ---------------------------------------------
+  // The round-the-clock detector needs a full day of history (span >= 24h,
+  // active >= 22 hrs-of-day), so a *fresh* account doing a dense burst evades it
+  // until it has run long enough — by which point it has polluted a day of stats.
+  // The burst detector catches it earlier with a physical-impossibility signal:
+  // a scrobble only registers after you've actually played most of a track, so a
+  // stream that logs tracks *faster than they can play* is not a human listening.
+  // Validated against the live user base over the same 72h window: this flagged
+  // four burst bots (impossibly-fast share 34–70%) and left every human clear
+  // (heaviest genuine listener sat at 18% — a comfortable margin below the 30% cut).
+  SWEEP_BURST_MIN_SCROBBLES: num({ default: 150 }), // sustained volume over the window
+  SWEEP_BURST_MAX_QUIET_MIN: num({ default: 120 }), // never takes a sleep-length break
+  SWEEP_BURST_FAST_FRACTION: num({ default: 0.5 }), // a scrobble is "impossibly fast" if it follows the prior by < this × the track's duration
+  SWEEP_BURST_MIN_FAST_PCT: num({ default: 30 }), // % of scrobbles that must be impossibly fast
 });


### PR DESCRIPTION
The offline sweep's round-the-clock detector needs a full day of history (span >= 24h, active >= 22 hrs-of-day), so a fresh account running a dense burst evades it until it has already polluted a day of stats — and flies under the inline 25/30min rate guard by pacing just below it.

Add a second detector built on a physical-impossibility signal: a scrobble only registers after most of a track has played, so a stream logging tracks faster than they can play is not a human listening. Gates on n >= 150, no sleep-length quiet break, and >= 30% of scrobbles landing within half the track's own duration of the prior one. Calibrated against the live user base over 72h: flagged four burst bots (impossibly-fast share 34-70%) and left every human clear (heaviest genuine listener at 18%).

Both detectors run each pass; candidates are de-duped by DID with the stronger round-the-clock reason winning. Tunable via new SWEEP_BURST_* env.