### PR TITLE
chore(deps): bump rockbox-wasm ^0.1.5 -> ^0.1.6

### DIFF
--- a/apps/web-mobile/package.json
+++ b/apps/web-mobile/package.json
@@ -38,7 +38,7 @@
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.6.3",
     "recharts": "^2.15.1",
-    "rockbox-wasm": "^0.1.5",
+    "rockbox-wasm": "^0.1.6",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1",
     "tailwindcss": "^4.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -73,7 +73,7 @@
     "react-i18next": "^15.4.0",
     "react-lazy-load-image-component": "^1.6.3",
     "recharts": "^2.15.1",
-    "rockbox-wasm": "^0.1.5",
+    "rockbox-wasm": "^0.1.6",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1",
     "swr": "^2.3.0",

--- a/bun.lock
+++ b/bun.lock
@@ -202,7 +202,7 @@
         "react-i18next": "^15.4.0",
         "react-lazy-load-image-component": "^1.6.3",
         "recharts": "^2.15.1",
-        "rockbox-wasm": "^0.1.5",
+        "rockbox-wasm": "^0.1.6",
         "styletron-engine-monolithic": "^1.0.0",
         "styletron-react": "^6.1.1",
         "swr": "^2.3.0",
@@ -270,7 +270,7 @@
         "react-hook-form": "^7.54.2",
         "react-router-dom": "^7.6.3",
         "recharts": "^2.15.1",
-        "rockbox-wasm": "^0.1.5",
+        "rockbox-wasm": "^0.1.6",
         "styletron-engine-monolithic": "^1.0.0",
         "styletron-react": "^6.1.1",
         "tailwindcss": "^4.0.0",
@@ -2900,7 +2900,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rockbox-wasm": ["rockbox-wasm@0.1.5", "", {}, "sha512-kqpcsaSTytYwdAmy9CzJRJ46pc0pfEI+ttO6jHHvnvZFcuzAJp5SkQ+VazQhT1p4PeInDGaLQ+8BqYG3lfAWOQ=="],
+    "rockbox-wasm": ["rockbox-wasm@0.1.6", "", {}, "sha512-8TiGqonV8MpyK7BrY8cfB7bwg7Jqjwy85NE0zZa4Mnrrxm6XQBtjZL+YXgz9kx1iwyLQEtrmNpwFBJNCiOSnJg=="],
 
     "rollup": ["rollup@4.52.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.4", "@rollup/rollup-android-arm64": "4.52.4", "@rollup/rollup-darwin-arm64": "4.52.4", "@rollup/rollup-darwin-x64": "4.52.4", "@rollup/rollup-freebsd-arm64": "4.52.4", "@rollup/rollup-freebsd-x64": "4.52.4", "@rollup/rollup-linux-arm-gnueabihf": "4.52.4", "@rollup/rollup-linux-arm-musleabihf": "4.52.4", "@rollup/rollup-linux-arm64-gnu": "4.52.4", "@rollup/rollup-linux-arm64-musl": "4.52.4", "@rollup/rollup-linux-loong64-gnu": "4.52.4", "@rollup/rollup-linux-ppc64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-musl": "4.52.4", "@rollup/rollup-linux-s390x-gnu": "4.52.4", "@rollup/rollup-linux-x64-gnu": "4.52.4", "@rollup/rollup-linux-x64-musl": "4.52.4", "@rollup/rollup-openharmony-arm64": "4.52.4", "@rollup/rollup-win32-arm64-msvc": "4.52.4", "@rollup/rollup-win32-ia32-msvc": "4.52.4", "@rollup/rollup-win32-x64-gnu": "4.52.4", "@rollup/rollup-win32-x64-msvc": "4.52.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ=="],
 


### PR DESCRIPTION
Picks up the next-track prefetch on the MP3/AAC progressive-stream path, so a whole-file next track (FLAC/…) is prefilled with no gap even when the current track is MP3/AAC.