### PR TITLE
feat(web-mobile): Navidrome-backed library + playlists; fix equalizer…

### DIFF
--- a/apps/web-mobile/package.json
+++ b/apps/web-mobile/package.json
@@ -38,7 +38,7 @@
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.6.3",
     "recharts": "^2.15.1",
-    "rockbox-wasm": "^0.1.8",
+    "rockbox-wasm": "^0.1.9",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1",
     "tailwindcss": "^4.0.0",

--- a/apps/web-mobile/src/App.tsx
+++ b/apps/web-mobile/src/App.tsx
@@ -11,6 +11,7 @@ import HomePage from "./pages/home";
 import LibraryPage from "./pages/library";
 import LibraryAlbumPage from "./pages/library/album";
 import LibraryArtistPage from "./pages/library/artist";
+import LibraryPlaylistPage from "./pages/library/playlist";
 import UploadPage from "./pages/library/upload";
 import Me from "./pages/me";
 import ProfilePage from "./pages/profile";
@@ -36,8 +37,9 @@ function App() {
         <Route path="/mirrors" element={<MirrorsPage />} />
         <Route path="/library" element={<LibraryPage />} />
         <Route path="/library/upload" element={<UploadPage />} />
-        <Route path="/library/:did/album/:rkey" element={<LibraryAlbumPage />} />
-        <Route path="/library/:did/artist/:rkey" element={<LibraryArtistPage />} />
+        <Route path="/library/album/:id" element={<LibraryAlbumPage />} />
+        <Route path="/library/artist/:id" element={<LibraryArtistPage />} />
+        <Route path="/library/playlist/:id" element={<LibraryPlaylistPage />} />
         <Route path="/:did/scrobble/:rkey" element={<SongPage />} />
         <Route path="/:did/song/:rkey" element={<SongPage />} />
         <Route path="/:did/artist/:rkey" element={<ArtistPage />} />

--- a/apps/web-mobile/src/api/navidrome.ts
+++ b/apps/web-mobile/src/api/navidrome.ts
@@ -67,6 +67,9 @@ function sr(data: unknown) {
   return (data as Record<string, unknown>)["subsonic-response"] as Record<string, unknown>;
 }
 
+const asArray = <T>(v: T | T[] | undefined): T[] =>
+  Array.isArray(v) ? v : v ? [v] : [];
+
 export function getCoverArtUrl(creds: NavidromeCredentials, id: string): string {
   const p = new URLSearchParams({ u: creds.handle, p: creds.apiKey, v: V, c: C, id });
   return `${NAVIDROME_URL}/rest/getCoverArt?${p}`;
@@ -167,9 +170,6 @@ export async function searchNavidrome(
 
 // -- Playlists ---------------------------------------------------------------
 
-const asArray = <T>(v: T | T[] | undefined): T[] =>
-  Array.isArray(v) ? v : v ? [v] : [];
-
 export async function fetchNavidromePlaylists(
   creds: NavidromeCredentials,
 ): Promise<NavidromePlaylist[]> {
@@ -193,7 +193,9 @@ export async function createNavidromePlaylist(
   name: string,
   songIds: string[] = [],
 ): Promise<string | undefined> {
-  const res = await axios.get(restUrl("createPlaylist"), { params: qp(creds, { name }) });
+  const res = await axios.get(restUrl("createPlaylist"), {
+    params: qp(creds, { name }),
+  });
   const id = (sr(res.data)?.playlist as { id?: string } | undefined)?.id;
   if (id && songIds.length) {
     for (const songId of songIds) {
@@ -215,7 +217,9 @@ export async function renameNavidromePlaylist(
   playlistId: string,
   name: string,
 ): Promise<void> {
-  await axios.get(restUrl("updatePlaylist"), { params: qp(creds, { playlistId, name }) });
+  await axios.get(restUrl("updatePlaylist"), {
+    params: qp(creds, { playlistId, name }),
+  });
 }
 
 export async function addTrackToNavidromePlaylist(

--- a/apps/web-mobile/src/api/uploads.ts
+++ b/apps/web-mobile/src/api/uploads.ts
@@ -209,6 +209,22 @@ export const deleteUpload = async (uploadId: string): Promise<void> => {
   });
 };
 
+export const deleteUploadByTrackId = async (trackId: string): Promise<void> => {
+  await axios.delete(`${API_URL}/uploads/by-track/${trackId}`, {
+    headers: headers(),
+  });
+};
+
+export const deleteAlbumById = async (
+  albumId: string,
+): Promise<{ deleted: number }> => {
+  const response = await axios.delete<{ status: string; deleted: number }>(
+    `${API_URL}/uploads/by-album/${albumId}`,
+    { headers: headers() },
+  );
+  return { deleted: response.data.deleted };
+};
+
 export const deleteAlbum = async (params: {
   albumUri?: string;
   albumArtist?: string;

--- a/apps/web-mobile/src/components/AddToPlaylistSheet/index.tsx
+++ b/apps/web-mobile/src/components/AddToPlaylistSheet/index.tsx
@@ -1,0 +1,124 @@
+import { IconPlaylist, IconPlus } from "@tabler/icons-react";
+import { useState } from "react";
+import {
+  useAddTrackToPlaylistMutation,
+  useCreatePlaylistMutation,
+  useNavidromePlaylistsQuery,
+} from "../../hooks/useNavidrome";
+
+// Bottom sheet for adding a Navidrome song to a playlist — pick an existing
+// playlist or create a new one containing the track. Shared by every track
+// context menu (library, album, artist, playlist views).
+
+export default function AddToPlaylistSheet({
+  open,
+  songId,
+  onClose,
+  onAdded,
+}: {
+  open: boolean;
+  songId: string | null;
+  onClose: () => void;
+  onAdded?: () => void;
+}) {
+  const { data: playlists = [], isLoading } = useNavidromePlaylistsQuery();
+  const addTrack = useAddTrackToPlaylistMutation();
+  const createPlaylist = useCreatePlaylistMutation();
+  const [creating, setCreating] = useState(false);
+
+  if (!open || !songId) return null;
+
+  const handleAdd = (playlistId: string) => {
+    addTrack.mutate({ playlistId, songId });
+    onAdded?.();
+    onClose();
+  };
+
+  const handleCreate = async () => {
+    const name = window.prompt("New playlist name")?.trim();
+    if (!name) return;
+    setCreating(true);
+    try {
+      await createPlaylist.mutateAsync({ name, songIds: [songId] });
+      onAdded?.();
+      onClose();
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[70]"
+        style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+        onClick={onClose}
+      />
+      <div
+        className="fixed left-0 right-0 bottom-0 z-[70] rounded-t-2xl flex flex-col"
+        style={{
+          backgroundColor: "var(--color-surface)",
+          borderTop: "1px solid var(--color-border)",
+          maxHeight: "70vh",
+        }}
+      >
+        <div className="flex justify-center pt-2 pb-1 shrink-0">
+          <div className="w-10 h-1 rounded-full" style={{ backgroundColor: "var(--color-border)" }} />
+        </div>
+        <div className="px-5 py-3 shrink-0" style={{ borderBottom: "1px solid var(--color-border)" }}>
+          <p className="m-0 text-sm font-semibold" style={{ color: "var(--color-text)" }}>
+            Add to playlist
+          </p>
+        </div>
+
+        <button
+          onClick={handleCreate}
+          disabled={creating}
+          className="w-full flex items-center gap-3 px-5 py-3.5 border-none bg-transparent cursor-pointer text-left text-sm font-semibold disabled:opacity-50"
+          style={{ color: "var(--color-primary)", borderBottom: "1px solid var(--color-border)" }}
+        >
+          <IconPlus size={18} /> New playlist
+        </button>
+
+        <div className="overflow-y-auto flex-1">
+          {isLoading && (
+            <p className="text-center text-sm py-6 m-0" style={{ color: "var(--color-text-muted)" }}>
+              Loading…
+            </p>
+          )}
+          {!isLoading && playlists.length === 0 && (
+            <p className="text-center text-sm py-6 m-0" style={{ color: "var(--color-text-muted)" }}>
+              No playlists yet
+            </p>
+          )}
+          {playlists.map((pl) => (
+            <button
+              key={pl.id}
+              onClick={() => handleAdd(pl.id)}
+              className="w-full flex items-center gap-3 px-5 py-3.5 border-none bg-transparent cursor-pointer text-left"
+              style={{ color: "var(--color-text)", borderBottom: "1px solid var(--color-border)" }}
+            >
+              <span style={{ color: "var(--color-text-muted)" }}>
+                <IconPlaylist size={18} />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm font-medium truncate">{pl.name}</span>
+                <span className="block text-xs" style={{ color: "var(--color-text-muted)" }}>
+                  {pl.songCount} track{pl.songCount !== 1 ? "s" : ""}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={onClose}
+          className="w-full py-4 text-center border-none bg-transparent cursor-pointer text-sm font-semibold shrink-0"
+          style={{ color: "var(--color-text-muted)", borderTop: "1px solid var(--color-border)" }}
+        >
+          Cancel
+        </button>
+      </div>
+    </>
+  );
+}

--- a/apps/web-mobile/src/components/EqualizerSheet/index.tsx
+++ b/apps/web-mobile/src/components/EqualizerSheet/index.tsx
@@ -192,12 +192,12 @@ export default function EqualizerSheet({ open, onClose }: Props) {
   return (
     <>
       <div
-        className="fixed inset-0 z-50"
+        className="fixed inset-0 z-[60]"
         style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
         onClick={onClose}
       />
       <div
-        className="fixed left-0 right-0 bottom-0 z-50 rounded-t-2xl"
+        className="fixed left-0 right-0 bottom-0 z-[60] rounded-t-2xl"
         style={{ backgroundColor: "var(--color-surface)", borderTop: "1px solid var(--color-border)" }}
       >
         {/* Handle */}

--- a/apps/web-mobile/src/components/MiniPlayer/index.tsx
+++ b/apps/web-mobile/src/components/MiniPlayer/index.tsx
@@ -34,6 +34,10 @@ import {
   streamUrlFor,
 } from "../../lib/audio/rockbox-engine";
 import { ensureStreamToken } from "../../api/uploads";
+import {
+  playMediaAnchor,
+  registerMediaAnchor,
+} from "../../lib/audio/media-session-anchor";
 import { SILENT_AUDIO_DATA_URI } from "../../lib/audio/silence";
 import EqualizerSheet from "../EqualizerSheet";
 import PlayerScreen from "../PlayerScreen";
@@ -356,6 +360,9 @@ export default function MiniPlayer() {
 
   const onPlayPause = async () => {
     if (!nowPlaying) return;
+    // Kick the Media Session anchor synchronously, inside this click, when
+    // resuming — an awaited resume would land outside the gesture and be blocked.
+    if (player === "upload" && !nowPlaying.isPlaying) playMediaAnchor();
     if (player === "upload") {
       const { p, loaded } = await ensureEngineQueue();
       // If we just (re)loaded the queue it's already playing the saved track —
@@ -489,6 +496,13 @@ export default function MiniPlayer() {
     if (!("mediaSession" in navigator)) return;
     navigator.mediaSession.playbackState = nowPlaying?.isPlaying ? "playing" : "paused";
   }, [nowPlaying?.isPlaying]);
+
+  // Register the silent <audio> so in-gesture click handlers (playNow, resume,
+  // media-key play) can start it — see media-session-anchor.
+  useEffect(() => {
+    registerMediaAnchor(silentRef.current);
+    return () => registerMediaAnchor(null);
+  }, []);
 
   // Keep the silent Media Session anchor playing whenever the engine plays.
   useEffect(() => {

--- a/apps/web-mobile/src/consts.ts
+++ b/apps/web-mobile/src/consts.ts
@@ -1,5 +1,7 @@
 export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 export const WS_URL = import.meta.env.VITE_WS_URL || "ws://localhost:8002";
+export const NAVIDROME_URL =
+  import.meta.env.VITE_NAVIDROME_URL || "https://navidrome.rocksky.app";
 
 export const LAST_7_DAYS = "LAST_7_DAYS";
 export const LAST_30_DAYS = "LAST_30_DAYS";

--- a/apps/web-mobile/src/hooks/useNavidrome.ts
+++ b/apps/web-mobile/src/hooks/useNavidrome.ts
@@ -71,8 +71,6 @@ export function songToQueueTrack(
     duration: song.duration * 1000,
     sha256: "",
     songUri: "",
-    trackNumber: song.track ?? null,
-    genre: song.genre ?? null,
     streamUrl: getNavidromeStreamUrl(creds, song.id),
   };
 }

--- a/apps/web-mobile/src/hooks/useUploadPlayer.tsx
+++ b/apps/web-mobile/src/hooks/useUploadPlayer.tsx
@@ -5,6 +5,7 @@ import { nowPlayingAtom } from "../atoms/nowpaying";
 import { playerAtom } from "../atoms/player";
 import { queueAtom, queueIndexAtom, type QueueTrack } from "../atoms/queue";
 import { ensureStreamToken } from "../api/uploads";
+import { playMediaAnchor } from "../lib/audio/media-session-anchor";
 import {
   ensureRockboxReady,
   registerTracks,
@@ -41,6 +42,10 @@ export function useUploadPlayer() {
   const playNow = useCallback(
     async (tracks: QueueTrack[], startIndex = 0) => {
       if (!tracks.length) return;
+      // Start the silent Media Session anchor synchronously, inside this click's
+      // user gesture — starting it later (from a React effect) is blocked by the
+      // autoplay policy, so the OS media controls would never appear.
+      playMediaAnchor();
       setNowPlaying(toNowPlaying(tracks[startIndex]));
       setPlayer("upload");
       // Boot the engine FIRST, synchronously within the click's user gesture.

--- a/apps/web-mobile/src/hooks/useUploads.tsx
+++ b/apps/web-mobile/src/hooks/useUploads.tsx
@@ -2,7 +2,9 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tansta
 import type { UploadAlbum, UploadArtist, UploadedTrack } from "../api/uploads";
 import {
   deleteAlbum,
+  deleteAlbumById,
   deleteUpload,
+  deleteUploadByTrackId,
   getUploadAlbums,
   getUploadArtists,
   getUploads,
@@ -56,6 +58,8 @@ const invalidateUploadCaches = (queryClient: ReturnType<typeof useQueryClient>) 
   queryClient.invalidateQueries({ queryKey: ["uploads-infinite"] });
   queryClient.invalidateQueries({ queryKey: ["uploads-albums-infinite"] });
   queryClient.invalidateQueries({ queryKey: ["uploads-artists-infinite"] });
+  // Library browsing now runs off Navidrome — refresh those views too.
+  queryClient.invalidateQueries({ queryKey: ["navidrome"] });
 };
 
 export const useDeleteUploadMutation = () => {
@@ -66,10 +70,26 @@ export const useDeleteUploadMutation = () => {
   });
 };
 
+export const useDeleteUploadByTrackIdMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteUploadByTrackId,
+    onSuccess: () => invalidateUploadCaches(queryClient),
+  });
+};
+
 export const useDeleteAlbumMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: deleteAlbum,
+    onSuccess: () => invalidateUploadCaches(queryClient),
+  });
+};
+
+export const useDeleteAlbumByIdMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteAlbumById,
     onSuccess: () => invalidateUploadCaches(queryClient),
   });
 };

--- a/apps/web-mobile/src/lib/audio/media-session-anchor.ts
+++ b/apps/web-mobile/src/lib/audio/media-session-anchor.ts
@@ -1,0 +1,25 @@
+// Media Session anchor — a hidden, silent <audio> element kept playing while
+// the wasm engine (Web Audio) plays, so the OS / lock-screen media controls
+// surface. Web Audio alone doesn't trigger Media Session.
+//
+// The catch: browsers only let <audio>.play() start from a user gesture. React
+// effects that react to state run AFTER the gesture, so play() there is rejected
+// by the autoplay policy and the anchor never starts. These helpers let the
+// click handlers (playNow, resume, media-key play) start the anchor
+// synchronously, inside the gesture.
+
+let anchor: HTMLAudioElement | null = null;
+
+export function registerMediaAnchor(el: HTMLAudioElement | null): void {
+  anchor = el;
+}
+
+export function playMediaAnchor(): void {
+  anchor?.play().catch(() => {
+    // Autoplay policy or no gesture — nothing we can do; ignore.
+  });
+}
+
+export function pauseMediaAnchor(): void {
+  anchor?.pause();
+}

--- a/apps/web-mobile/src/pages/library/album.tsx
+++ b/apps/web-mobile/src/pages/library/album.tsx
@@ -1,70 +1,46 @@
-import dayjs from "dayjs";
 import {
   IconArrowLeft,
   IconArrowsShuffle,
   IconDots,
   IconMusic,
   IconPlayerPlay,
+  IconPlaylist,
   IconTrash,
   IconVinyl,
 } from "@tabler/icons-react";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import type { UploadedTrack } from "../../api/uploads";
+import ContentLoader from "react-content-loader";
+import {
+  getCoverArtUrl,
+  type NavidromeSong,
+} from "../../api/navidrome";
 import type { QueueTrack } from "../../atoms/queue";
 import {
-  useDeleteAlbumMutation,
-  useDeleteUploadMutation,
-  useUploadsQuery,
+  useNavidromeAlbumQuery,
+  useNavidromeCredentials,
+  songToQueueTrack,
+} from "../../hooks/useNavidrome";
+import {
+  useDeleteAlbumByIdMutation,
+  useDeleteUploadByTrackIdMutation,
 } from "../../hooks/useUploads";
 import { useUploadPlayer } from "../../hooks/useUploadPlayer";
+import AddToPlaylistSheet from "../../components/AddToPlaylistSheet";
 import Main from "../../layouts/Main";
-import ContentLoader from "react-content-loader";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatDuration(ms: number) {
-  const s = Math.floor(ms / 1000);
-  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+function formatDuration(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-function formatTotalDuration(ms: number) {
-  const s = Math.floor(ms / 1000);
-  const h = Math.floor(s / 3600);
-  const m = Math.floor((s % 3600) / 60);
+function formatTotalDuration(seconds: number) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
   if (h > 0) return `${h} hr ${m} min`;
   return `${m} min`;
 }
-
-function formatReleaseDate(raw: string | null | undefined, year: number | null | undefined): string | null {
-  if (raw) {
-    const parts = raw.split("-");
-    if (parts.length === 3) { const d = dayjs(raw); if (d.isValid()) return d.format("D MMMM YYYY"); }
-    if (parts.length === 2) { const d = dayjs(`${raw}-01`); if (d.isValid()) return d.format("MMMM YYYY"); }
-  }
-  if (year) return String(year);
-  return null;
-}
-
-function toQueueTrack(item: UploadedTrack): QueueTrack {
-  return {
-    uploadId: item.upload.id,
-    title: item.track.title,
-    artist: item.track.artist,
-    albumArtist: item.track.albumArtist,
-    album: item.track.album,
-    albumArt: item.track.albumArt,
-    duration: item.track.duration,
-    sha256: item.track.sha256,
-    songUri: item.track.uri ?? "",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Action sheet
-// ---------------------------------------------------------------------------
 
 function ActionSheet({ open, onClose, children }: { open: boolean; onClose: () => void; children: React.ReactNode }) {
   if (!open) return null;
@@ -84,79 +60,42 @@ function ActionSheet({ open, onClose, children }: { open: boolean; onClose: () =
   );
 }
 
-function SheetItem({
-  label,
-  onClick,
-  icon,
-  danger,
-  disabled,
-}: {
-  label: string;
-  onClick: () => void;
-  icon?: React.ReactNode;
-  danger?: boolean;
-  disabled?: boolean;
-}) {
+function SheetItem({ label, onClick, icon, danger, disabled }: { label: string; onClick: () => void; icon?: React.ReactNode; danger?: boolean; disabled?: boolean }) {
   const color = danger ? "#e55" : "var(--color-text)";
   return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className="w-full flex items-center gap-3 px-5 py-3.5 border-none bg-transparent cursor-pointer text-left text-sm font-medium disabled:opacity-50"
-      style={{ color }}
-    >
+    <button onClick={onClick} disabled={disabled} className="w-full flex items-center gap-3 px-5 py-3.5 border-none bg-transparent cursor-pointer text-left text-sm font-medium disabled:opacity-50" style={{ color }}>
       {icon && <span style={{ color: danger ? "#e55" : "var(--color-text-muted)" }}>{icon}</span>}
       {label}
     </button>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
-
 export default function LibraryAlbumPage() {
   const navigate = useNavigate();
-  const { did, rkey } = useParams<{ did: string; rkey: string }>();
+  const { id } = useParams<{ id: string }>();
   const { playNow, playNext, playLast } = useUploadPlayer();
-  const [sheetTrack, setSheetTrack] = useState<UploadedTrack | null>(null);
-  const deleteUploadMutation = useDeleteUploadMutation();
-  const deleteAlbumMutation = useDeleteAlbumMutation();
+  const { data: creds } = useNavidromeCredentials();
+  const [sheetSong, setSheetSong] = useState<NavidromeSong | null>(null);
+  const [addToPlaylistSongId, setAddToPlaylistSongId] = useState<string | null>(null);
+  const deleteTrack = useDeleteUploadByTrackIdMutation();
+  const deleteAlbum = useDeleteAlbumByIdMutation();
 
-  const albumUri = `at://${did}/app.rocksky.album/${rkey}`;
-  const { data: allUploads = [], isLoading } = useUploadsQuery(0, 1000);
+  const { data: album, isLoading } = useNavidromeAlbumQuery(id ?? "");
 
-  const tracks = useMemo(
-    () => allUploads
-      .filter((item) => item.track.albumUri === albumUri)
-      .sort((a, b) => (a.track.trackNumber ?? 0) - (b.track.trackNumber ?? 0)),
-    [allUploads, albumUri],
+  const albumArt = creds && album?.coverArt ? getCoverArtUrl(creds, album.coverArt) : null;
+  const songs: NavidromeSong[] = useMemo(() => album?.song ?? [], [album]);
+  const totalDuration = album?.duration ?? songs.reduce((sum, s) => sum + s.duration, 0);
+
+  const queue = useCallback(
+    (): QueueTrack[] => (creds ? songs.map((s) => songToQueueTrack(s, creds, albumArt)) : []),
+    [creds, songs, albumArt],
   );
 
-  const albumArt = tracks[0]?.track.albumArt ?? null;
-  const album = tracks[0]?.track.album ?? "";
-  const albumArtist = tracks[0]?.track.albumArtist ?? "";
-  const totalDuration = tracks.reduce((sum, t) => sum + t.track.duration, 0);
-  const releaseDate = formatReleaseDate(tracks[0]?.albumReleaseDate, tracks[0]?.albumYear);
-  const copyrightMessage = tracks[0]?.track.copyrightMessage ?? null;
+  const handlePlay = useCallback(() => playNow(queue()), [queue, playNow]);
+  const handleShuffle = useCallback(() => playNow([...queue()].sort(() => Math.random() - 0.5)), [queue, playNow]);
+  const handleTrackPlay = useCallback((idx: number) => playNow(queue(), idx), [queue, playNow]);
 
-  const handlePlay = useCallback(() => playNow(tracks.map(toQueueTrack)), [tracks, playNow]);
-  const handleShuffle = useCallback(() => playNow([...tracks.map(toQueueTrack)].sort(() => Math.random() - 0.5)), [tracks, playNow]);
-  const handleTrackPlay = useCallback((item: UploadedTrack) => {
-    const queue = tracks.map(toQueueTrack);
-    const idx = tracks.findIndex((t) => t.upload.id === item.upload.id);
-    playNow(queue, idx >= 0 ? idx : 0);
-  }, [tracks, playNow]);
-
-  // Parse artist URI for navigation
-  const artistParsed = (() => {
-    const uri = tracks[0]?.track.artistUri;
-    if (!uri) return null;
-    const m = uri.match(/^at:\/\/([^/]+)\/[^/]+\/([^/]+)$/);
-    return m ? { did: m[1], rkey: m[2] } : null;
-  })();
-
-  if (isLoading) {
+  if (isLoading || !creds) {
     return (
       <Main>
         <div className="px-4 pt-4">
@@ -177,10 +116,22 @@ export default function LibraryAlbumPage() {
     );
   }
 
+  if (!album) {
+    return (
+      <Main>
+        <div className="px-4 pt-4">
+          <button onClick={() => navigate("/library")} className="flex items-center gap-1 text-sm border-none bg-transparent cursor-pointer p-0 mb-4" style={{ color: "var(--color-text-muted)" }}>
+            <IconArrowLeft size={16} /> Library
+          </button>
+          <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Album not found.</p>
+        </div>
+      </Main>
+    );
+  }
+
   return (
     <Main>
       <div className="px-4 pt-4 pb-32">
-        {/* Back */}
         <button
           onClick={() => navigate("/library")}
           className="flex items-center gap-1 text-sm border-none bg-transparent cursor-pointer p-0 mb-4"
@@ -193,24 +144,25 @@ export default function LibraryAlbumPage() {
         <div className="flex gap-4 items-end mb-6">
           <div className="w-36 h-36 rounded-2xl overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)", boxShadow: "0 8px 32px rgba(0,0,0,0.2)" }}>
             {albumArt ? (
-              <img src={albumArt} alt={album} className="w-full h-full object-cover" />
+              <img src={albumArt} alt={album.name} className="w-full h-full object-cover" />
             ) : (
               <IconVinyl size={56} color="var(--color-text-muted)" />
             )}
           </div>
           <div className="flex-1 min-w-0 pb-1">
             <h1 className="text-lg font-bold m-0 mb-1 leading-tight" style={{ color: "var(--color-text)", fontFamily: "RockfordSansBold" }}>
-              {album}
+              {album.name}
             </h1>
             <p
               className="text-sm font-semibold m-0 mb-1 cursor-pointer"
               style={{ color: "var(--color-primary)" }}
-              onClick={() => { if (artistParsed) navigate(`/library/${artistParsed.did}/artist/${artistParsed.rkey}`); }}
+              onClick={() => { if (album.artistId) navigate(`/library/artist/${album.artistId}`); }}
             >
-              {albumArtist}
+              {album.artist}
             </p>
             <p className="text-xs m-0" style={{ color: "var(--color-text-muted)" }}>
-              {tracks.length} track{tracks.length !== 1 ? "s" : ""} · {formatTotalDuration(totalDuration)}
+              {songs.length} track{songs.length !== 1 ? "s" : ""} · {formatTotalDuration(totalDuration)}
+              {album.year ? ` · ${album.year}` : ""}
             </p>
             <div className="flex gap-3 mt-3">
               <button
@@ -228,19 +180,10 @@ export default function LibraryAlbumPage() {
                 <IconArrowsShuffle size={14} /> Shuffle
               </button>
               <button
-                disabled={deleteAlbumMutation.isPending || tracks.length === 0}
+                disabled={deleteAlbum.isPending || songs.length === 0}
                 onClick={() => {
-                  if (
-                    !window.confirm(
-                      `Delete every track from "${album}" by ${albumArtist}? This cannot be undone.`,
-                    )
-                  ) {
-                    return;
-                  }
-                  deleteAlbumMutation.mutate(
-                    { albumUri },
-                    { onSuccess: () => navigate("/library") },
-                  );
+                  if (!window.confirm(`Delete every track from "${album.name}" by ${album.artist}? This cannot be undone.`)) return;
+                  deleteAlbum.mutate(album.id, { onSuccess: () => navigate("/library") });
                 }}
                 className="flex items-center gap-2 px-4 py-2 rounded-full border-none cursor-pointer text-sm font-semibold bg-transparent disabled:opacity-50"
                 style={{ color: "#e55" }}
@@ -253,94 +196,83 @@ export default function LibraryAlbumPage() {
 
         {/* Track list */}
         <div className="flex flex-col">
-          {tracks.map((item, idx) => (
+          {songs.map((song, idx) => (
             <div
-              key={item.upload.id}
+              key={song.id}
               className="flex items-center gap-3 py-3 active:opacity-70"
               style={{ borderBottom: "1px solid var(--color-border)" }}
-              onClick={() => handleTrackPlay(item)}
+              onClick={() => handleTrackPlay(idx)}
             >
               <span className="w-6 text-right text-xs shrink-0" style={{ color: "var(--color-text-muted)" }}>
-                {item.track.trackNumber ?? idx + 1}
+                {song.track ?? idx + 1}
               </span>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>
-                  {item.track.title}
+                  {song.title}
                 </p>
-                {item.track.artist !== albumArtist && (
+                {song.artist !== album.artist && (
                   <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
-                    {item.track.artist}
+                    {song.artist}
                   </p>
                 )}
               </div>
               <span className="text-xs shrink-0" style={{ color: "var(--color-text-muted)" }}>
-                {formatDuration(item.track.duration)}
+                {formatDuration(song.duration)}
               </span>
               <button
                 className="p-1.5 border-none bg-transparent cursor-pointer rounded-lg shrink-0"
                 style={{ color: "var(--color-text-muted)" }}
-                onClick={(e) => { e.stopPropagation(); setSheetTrack(item); }}
+                onClick={(e) => { e.stopPropagation(); setSheetSong(song); }}
               >
                 <IconDots size={16} />
               </button>
             </div>
           ))}
         </div>
-
-        {/* Release date + copyright */}
-        {(releaseDate || copyrightMessage) && (
-          <div className="mt-8">
-            {releaseDate && (
-              <p className="text-sm m-0 mb-1" style={{ color: "var(--color-text-muted)" }}>{releaseDate}</p>
-            )}
-            {copyrightMessage && (
-              <p className="text-xs m-0" style={{ color: "var(--color-text-muted)", opacity: 0.7 }}>{copyrightMessage}</p>
-            )}
-          </div>
-        )}
       </div>
 
       {/* Track action sheet */}
-      <ActionSheet open={!!sheetTrack} onClose={() => setSheetTrack(null)}>
-        {sheetTrack && (
+      <ActionSheet open={!!sheetSong} onClose={() => setSheetSong(null)}>
+        {sheetSong && creds && (
           <>
             <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
               <div className="w-10 h-10 rounded-lg overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)" }}>
-                {sheetTrack.track.albumArt
-                  ? <img src={sheetTrack.track.albumArt} alt="" className="w-full h-full object-cover" />
+                {albumArt
+                  ? <img src={albumArt} alt="" className="w-full h-full object-cover" />
                   : <IconMusic size={16} color="var(--color-text-muted)" />}
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetTrack.track.title}</p>
-                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetTrack.track.artist}</p>
+                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetSong.title}</p>
+                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetSong.artist}</p>
               </div>
             </div>
-            <SheetItem label="Play" onClick={() => { handleTrackPlay(sheetTrack); setSheetTrack(null); }} />
-            <SheetItem label="Play next" onClick={() => { playNext(toQueueTrack(sheetTrack)); setSheetTrack(null); }} />
-            <SheetItem label="Add to queue" onClick={() => { playLast(toQueueTrack(sheetTrack)); setSheetTrack(null); }} />
-            {artistParsed && (
-              <SheetItem label="Go to artist" onClick={() => { navigate(`/library/${artistParsed.did}/artist/${artistParsed.rkey}`); setSheetTrack(null); }} />
+            <SheetItem label="Play" onClick={() => { const i = songs.findIndex((s) => s.id === sheetSong.id); handleTrackPlay(i >= 0 ? i : 0); setSheetSong(null); }} />
+            <SheetItem label="Play next" onClick={() => { playNext(songToQueueTrack(sheetSong, creds, albumArt)); setSheetSong(null); }} />
+            <SheetItem label="Add to queue" onClick={() => { playLast(songToQueueTrack(sheetSong, creds, albumArt)); setSheetSong(null); }} />
+            <SheetItem icon={<IconPlaylist size={16} />} label="Add to playlist" onClick={() => { setAddToPlaylistSongId(sheetSong.id); setSheetSong(null); }} />
+            {sheetSong.artistId && (
+              <SheetItem label="Go to artist" onClick={() => { navigate(`/library/artist/${sheetSong.artistId}`); setSheetSong(null); }} />
             )}
             <SheetItem
               icon={<IconTrash size={16} />}
               label="Delete track"
               danger
-              disabled={deleteUploadMutation.isPending}
+              disabled={deleteTrack.isPending}
               onClick={() => {
-                if (
-                  !window.confirm(
-                    `Delete "${sheetTrack.track.title}" from your library? This cannot be undone.`,
-                  )
-                ) {
-                  return;
-                }
-                deleteUploadMutation.mutate(sheetTrack.upload.id);
-                setSheetTrack(null);
+                if (!window.confirm(`Delete "${sheetSong.title}" from your library? This cannot be undone.`)) return;
+                deleteTrack.mutate(sheetSong.id);
+                setSheetSong(null);
               }}
             />
           </>
         )}
       </ActionSheet>
+
+      <AddToPlaylistSheet
+        open={!!addToPlaylistSongId}
+        songId={addToPlaylistSongId}
+        onClose={() => setAddToPlaylistSongId(null)}
+      />
     </Main>
   );
 }

--- a/apps/web-mobile/src/pages/library/artist.tsx
+++ b/apps/web-mobile/src/pages/library/artist.tsx
@@ -1,122 +1,62 @@
 import {
   IconArrowLeft,
   IconArrowsShuffle,
-  IconDots,
-  IconMusic,
   IconPlayerPlay,
   IconVinyl,
 } from "@tabler/icons-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import ContentLoader from "react-content-loader";
-import type { UploadedTrack } from "../../api/uploads";
+import {
+  fetchNavidromeAlbum,
+  getCoverArtUrl,
+  type NavidromeAlbum,
+  type NavidromeCredentials,
+} from "../../api/navidrome";
 import type { QueueTrack } from "../../atoms/queue";
-import { useArtistQuery } from "../../hooks/useLibrary";
-import { useUploadsQuery } from "../../hooks/useUploads";
+import {
+  useNavidromeArtistQuery,
+  useNavidromeCredentials,
+  songToQueueTrack,
+} from "../../hooks/useNavidrome";
 import { useUploadPlayer } from "../../hooks/useUploadPlayer";
 import Main from "../../layouts/Main";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatDuration(ms: number) {
-  const s = Math.floor(ms / 1000);
-  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
-}
-
-function toQueueTrack(item: UploadedTrack): QueueTrack {
-  return {
-    uploadId: item.upload.id,
-    title: item.track.title,
-    artist: item.track.artist,
-    albumArtist: item.track.albumArtist,
-    album: item.track.album,
-    albumArt: item.track.albumArt,
-    duration: item.track.duration,
-    sha256: item.track.sha256,
-    songUri: item.track.uri ?? "",
-  };
-}
-
-function parseAtUri(uri: string | null | undefined) {
-  if (!uri) return null;
-  const m = uri.match(/^at:\/\/([^/]+)\/[^/]+\/([^/]+)$/);
-  return m ? { did: m[1], rkey: m[2] } : null;
-}
-
-// ---------------------------------------------------------------------------
-// Action sheet
-// ---------------------------------------------------------------------------
-
-function ActionSheet({ open, onClose, children }: { open: boolean; onClose: () => void; children: React.ReactNode }) {
-  if (!open) return null;
-  return (
-    <>
-      <div className="fixed inset-0 z-40" style={{ backgroundColor: "rgba(0,0,0,0.5)" }} onClick={onClose} />
-      <div className="fixed left-0 right-0 bottom-0 z-50 rounded-t-2xl" style={{ backgroundColor: "var(--color-surface)", borderTop: "1px solid var(--color-border)" }}>
-        <div className="flex justify-center pt-2 pb-1">
-          <div className="w-10 h-1 rounded-full" style={{ backgroundColor: "var(--color-border)" }} />
-        </div>
-        {children}
-        <button onClick={onClose} className="w-full py-4 text-center border-none bg-transparent cursor-pointer text-sm font-semibold" style={{ color: "var(--color-text-muted)", borderTop: "1px solid var(--color-border)" }}>
-          Cancel
-        </button>
-      </div>
-    </>
+async function fetchAllArtistTracks(
+  albums: NavidromeAlbum[],
+  creds: NavidromeCredentials,
+): Promise<QueueTrack[]> {
+  const results = await Promise.all(
+    albums.map(async (a) => {
+      const full = await fetchNavidromeAlbum(creds, a.id);
+      const artUrl = full?.coverArt ? getCoverArtUrl(creds, full.coverArt) : null;
+      return (full?.song ?? []).map((s) => songToQueueTrack(s, creds, artUrl));
+    }),
   );
+  return results.flat();
 }
-
-function SheetItem({ label, onClick }: { label: string; onClick: () => void }) {
-  return (
-    <button onClick={onClick} className="w-full flex items-center gap-3 px-5 py-3.5 border-none bg-transparent cursor-pointer text-left text-sm font-medium" style={{ color: "var(--color-text)" }}>
-      {label}
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
 
 export default function LibraryArtistPage() {
   const navigate = useNavigate();
-  const { did, rkey } = useParams<{ did: string; rkey: string }>();
-  const { playNow, playNext, playLast } = useUploadPlayer();
-  const [sheetTrack, setSheetTrack] = useState<UploadedTrack | null>(null);
+  const { id } = useParams<{ id: string }>();
+  const { playNow } = useUploadPlayer();
+  const { data: creds } = useNavidromeCredentials();
+  const { data: artist, isLoading } = useNavidromeArtistQuery(id ?? "");
 
-  const artistUri = `at://${did}/app.rocksky.artist/${rkey}`;
-  const { data: allUploads = [], isLoading } = useUploadsQuery(0, 1000);
-  const { data: artistData } = useArtistQuery(did!, rkey!);
+  const albums: NavidromeAlbum[] = artist?.album ?? [];
 
-  const tracks = useMemo(
-    () => allUploads.filter((item) => item.track.artistUri === artistUri),
-    [allUploads, artistUri],
-  );
+  const handlePlayAll = useCallback(async () => {
+    if (!creds) return;
+    playNow(await fetchAllArtistTracks(albums, creds));
+  }, [albums, creds, playNow]);
 
-  const artistName = artistData?.name ?? tracks[0]?.track.albumArtist ?? "";
-  const artistPicture = artistData?.picture ?? null;
+  const handleShuffle = useCallback(async () => {
+    if (!creds) return;
+    const tracks = await fetchAllArtistTracks(albums, creds);
+    playNow([...tracks].sort(() => Math.random() - 0.5));
+  }, [albums, creds, playNow]);
 
-  const albums = useMemo(() => {
-    const map = new Map<string, { album: string; albumArt: string | null; albumUri: string | null; count: number }>();
-    for (const item of tracks) {
-      if (!map.has(item.track.album)) {
-        map.set(item.track.album, { album: item.track.album, albumArt: item.track.albumArt, albumUri: item.track.albumUri ?? null, count: 0 });
-      }
-      map.get(item.track.album)!.count++;
-    }
-    return Array.from(map.values()).sort((a, b) => a.album.localeCompare(b.album));
-  }, [tracks]);
-
-  const handlePlayAll = useCallback(() => playNow(tracks.map(toQueueTrack)), [tracks, playNow]);
-  const handleShuffle = useCallback(() => playNow([...tracks.map(toQueueTrack)].sort(() => Math.random() - 0.5)), [tracks, playNow]);
-  const handleTrackPlay = useCallback((item: UploadedTrack) => {
-    const queue = tracks.map(toQueueTrack);
-    const idx = tracks.findIndex((t) => t.upload.id === item.upload.id);
-    playNow(queue, idx >= 0 ? idx : 0);
-  }, [tracks, playNow]);
-
-  if (isLoading) {
+  if (isLoading || !creds || !artist) {
     return (
       <Main>
         <div className="px-4 pt-4">
@@ -136,7 +76,6 @@ export default function LibraryArtistPage() {
   return (
     <Main>
       <div className="pb-32">
-        {/* Back */}
         <div className="px-4 pt-4 mb-2">
           <button
             onClick={() => navigate("/library")}
@@ -153,17 +92,17 @@ export default function LibraryArtistPage() {
             className="w-28 h-28 rounded-full overflow-hidden flex items-center justify-center mb-4 text-4xl font-bold"
             style={{ backgroundColor: "var(--color-menu-hover)", color: "var(--color-text-muted)", boxShadow: "0 8px 32px rgba(0,0,0,0.2)" }}
           >
-            {artistPicture ? (
-              <img src={artistPicture} alt={artistName} className="w-full h-full object-cover" />
+            {artist.artistImageUrl ? (
+              <img src={artist.artistImageUrl} alt={artist.name} className="w-full h-full object-cover" />
             ) : (
-              artistName.charAt(0).toUpperCase()
+              artist.name.charAt(0).toUpperCase()
             )}
           </div>
           <h1 className="text-xl font-bold m-0 mb-1" style={{ color: "var(--color-text)", fontFamily: "RockfordSansBold" }}>
-            {artistName}
+            {artist.name}
           </h1>
           <p className="text-sm m-0 mb-4" style={{ color: "var(--color-text-muted)" }}>
-            {albums.length} album{albums.length !== 1 ? "s" : ""} · {tracks.length} track{tracks.length !== 1 ? "s" : ""}
+            {albums.length} album{albums.length !== 1 ? "s" : ""}
           </p>
           <div className="flex gap-3">
             <button
@@ -189,98 +128,34 @@ export default function LibraryArtistPage() {
             <h2 className="text-sm font-bold m-0 mb-3" style={{ color: "var(--color-text)" }}>Albums</h2>
             <div className="grid grid-cols-2 gap-4">
               {albums.map((alb) => {
-                const parsed = parseAtUri(alb.albumUri);
+                const artUrl = alb.coverArt ? getCoverArtUrl(creds, alb.coverArt) : null;
                 return (
                   <div
-                    key={alb.album}
+                    key={alb.id}
                     className="cursor-pointer"
-                    onClick={() => { if (parsed) navigate(`/library/${parsed.did}/album/${parsed.rkey}`); }}
+                    onClick={() => navigate(`/library/album/${alb.id}`)}
                   >
                     <div
                       className="w-full aspect-square rounded-xl overflow-hidden flex items-center justify-center mb-2"
                       style={{ backgroundColor: "var(--color-menu-hover)" }}
                     >
-                      {alb.albumArt ? (
-                        <img src={alb.albumArt} alt={alb.album} className="w-full h-full object-cover" />
+                      {artUrl ? (
+                        <img src={artUrl} alt={alb.name} className="w-full h-full object-cover" />
                       ) : (
                         <IconVinyl size={36} color="var(--color-text-muted)" />
                       )}
                     </div>
-                    <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{alb.album}</p>
-                    <p className="text-xs m-0 mt-0.5" style={{ color: "var(--color-text-muted)" }}>{alb.count} track{alb.count !== 1 ? "s" : ""}</p>
+                    <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{alb.name}</p>
+                    <p className="text-xs m-0 mt-0.5" style={{ color: "var(--color-text-muted)" }}>
+                      {alb.year ?? `${alb.songCount} track${alb.songCount !== 1 ? "s" : ""}`}
+                    </p>
                   </div>
                 );
               })}
             </div>
           </div>
         )}
-
-        {/* Tracks */}
-        <div className="px-4 pt-5">
-          <h2 className="text-sm font-bold m-0 mb-1" style={{ color: "var(--color-text)" }}>Tracks</h2>
-          {tracks.map((item) => (
-            <div
-              key={item.upload.id}
-              className="flex items-center gap-3 py-3 active:opacity-70"
-              style={{ borderBottom: "1px solid var(--color-border)" }}
-              onClick={() => handleTrackPlay(item)}
-            >
-              <div
-                className="w-10 h-10 rounded-lg shrink-0 overflow-hidden flex items-center justify-center"
-                style={{ backgroundColor: "var(--color-menu-hover)" }}
-              >
-                {item.track.albumArt ? (
-                  <img src={item.track.albumArt} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  <IconMusic size={16} color="var(--color-text-muted)" />
-                )}
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{item.track.title}</p>
-                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{item.track.album}</p>
-              </div>
-              <span className="text-xs shrink-0" style={{ color: "var(--color-text-muted)" }}>
-                {formatDuration(item.track.duration)}
-              </span>
-              <button
-                className="p-1.5 border-none bg-transparent cursor-pointer rounded-lg shrink-0"
-                style={{ color: "var(--color-text-muted)" }}
-                onClick={(e) => { e.stopPropagation(); setSheetTrack(item); }}
-              >
-                <IconDots size={16} />
-              </button>
-            </div>
-          ))}
-        </div>
       </div>
-
-      {/* Track action sheet */}
-      <ActionSheet open={!!sheetTrack} onClose={() => setSheetTrack(null)}>
-        {sheetTrack && (
-          <>
-            <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
-              <div className="w-10 h-10 rounded-lg overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)" }}>
-                {sheetTrack.track.albumArt
-                  ? <img src={sheetTrack.track.albumArt} alt="" className="w-full h-full object-cover" />
-                  : <IconMusic size={16} color="var(--color-text-muted)" />}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetTrack.track.title}</p>
-                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetTrack.track.artist}</p>
-              </div>
-            </div>
-            <SheetItem label="Play" onClick={() => { handleTrackPlay(sheetTrack); setSheetTrack(null); }} />
-            <SheetItem label="Play next" onClick={() => { playNext(toQueueTrack(sheetTrack)); setSheetTrack(null); }} />
-            <SheetItem label="Add to queue" onClick={() => { playLast(toQueueTrack(sheetTrack)); setSheetTrack(null); }} />
-            {(() => {
-              const parsed = parseAtUri(sheetTrack.track.albumUri);
-              return parsed ? (
-                <SheetItem label="Go to album" onClick={() => { navigate(`/library/${parsed.did}/album/${parsed.rkey}`); setSheetTrack(null); }} />
-              ) : null;
-            })()}
-          </>
-        )}
-      </ActionSheet>
     </Main>
   );
 }

--- a/apps/web-mobile/src/pages/library/index.tsx
+++ b/apps/web-mobile/src/pages/library/index.tsx
@@ -3,82 +3,79 @@ import {
   IconDots,
   IconMusic,
   IconPlayerPlay,
+  IconPlaylist,
+  IconPlus,
+  IconSearch,
   IconTrash,
   IconUpload,
+  IconUser,
   IconVinyl,
+  IconX,
 } from "@tabler/icons-react";
-import { useCallback, useMemo, useRef, useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ContentLoader from "react-content-loader";
 import { Link, useNavigate } from "react-router-dom";
-import { getAlbumTracks } from "../../api/uploads";
-import type {
-  UploadAlbum,
-  UploadArtist,
-  UploadedTrack,
-} from "../../api/uploads";
-import type { QueueTrack } from "../../atoms/queue";
-import { useArtistQuery } from "../../hooks/useLibrary";
 import {
-  useDeleteAlbumMutation,
-  useDeleteUploadMutation,
-  useInfiniteUploadAlbumsQuery,
-  useInfiniteUploadArtistsQuery,
-  useInfiniteUploadsQuery,
+  fetchNavidromeAlbum,
+  fetchNavidromePlaylist,
+  getCoverArtUrl,
+  type NavidromeAlbum,
+  type NavidromeArtist,
+  type NavidromePlaylist,
+  type NavidromeSong,
+} from "../../api/navidrome";
+import type { QueueTrack } from "../../atoms/queue";
+import {
+  useCreatePlaylistMutation,
+  useDeletePlaylistMutation,
+  useNavidromeAlbumsQuery,
+  useNavidromeArtistsQuery,
+  useNavidromeCredentials,
+  useNavidromePlaylistsQuery,
+  useNavidromeTracksQuery,
+  useRenamePlaylistMutation,
+  songToQueueTrack,
+} from "../../hooks/useNavidrome";
+import {
+  useDeleteAlbumByIdMutation,
+  useDeleteUploadByTrackIdMutation,
 } from "../../hooks/useUploads";
 import { useUploadPlayer } from "../../hooks/useUploadPlayer";
+import AddToPlaylistSheet from "../../components/AddToPlaylistSheet";
 import Main from "../../layouts/Main";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatDuration(ms: number) {
-  const s = Math.floor(ms / 1000);
-  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+function formatDuration(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-function albumKey(albumArtist: string, album: string) {
-  return `${albumArtist}|||${album}`;
-}
-
+// Callback-ref sentinel: the observer (re)attaches whenever the sentinel node
+// mounts, so infinite scroll works even for tabs mounted lazily after a switch.
 function useInfiniteScrollSentinel(
   hasNextPage: boolean,
   isFetchingNextPage: boolean,
   fetchNextPage: () => unknown,
 ) {
-  const ref = useRef<HTMLDivElement>(null);
+  const [el, setEl] = useState<HTMLDivElement | null>(null);
   useEffect(() => {
-    const el = ref.current;
     if (!el) return;
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-        fetchNextPage();
-      }
-    });
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: "400px 0px" },
+    );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-  return ref;
-}
-
-function parseAtUri(uri: string | null | undefined) {
-  if (!uri) return null;
-  const m = uri.match(/^at:\/\/([^/]+)\/[^/]+\/([^/]+)$/);
-  return m ? { did: m[1], rkey: m[2] } : null;
-}
-
-function toQueueTrack(item: UploadedTrack): QueueTrack {
-  return {
-    uploadId: item.upload.id,
-    title: item.track.title,
-    artist: item.track.artist,
-    albumArtist: item.track.albumArtist,
-    album: item.track.album,
-    albumArt: item.track.albumArt,
-    duration: item.track.duration,
-    sha256: item.track.sha256,
-    songUri: item.track.uri ?? "",
-  };
+  }, [el, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  return setEl;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,29 +98,6 @@ function TrackSkeleton() {
       <rect x="96" y="34" rx="3" ry="3" width="90" height="10" />
       <rect x="308" y="23" rx="3" ry="3" width="36" height="12" />
     </ContentLoader>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Artist avatar with picture fetch
-// ---------------------------------------------------------------------------
-
-function ArtistAvatar({ artistUri, name }: { artistUri: string | null; name: string }) {
-  const parsed = parseAtUri(artistUri);
-  const { data } = useArtistQuery(parsed?.did ?? "", parsed?.rkey ?? "");
-  const picture = data?.picture ?? null;
-
-  return (
-    <div
-      className="w-16 h-16 rounded-full overflow-hidden shrink-0 flex items-center justify-center text-2xl font-bold"
-      style={{ backgroundColor: "var(--color-menu-hover)", color: "var(--color-text-muted)" }}
-    >
-      {picture ? (
-        <img src={picture} alt={name} className="w-full h-full object-cover" />
-      ) : (
-        name.charAt(0).toUpperCase()
-      )}
-    </div>
   );
 }
 
@@ -199,35 +173,54 @@ function SheetItem({
 // Page
 // ---------------------------------------------------------------------------
 
-type Tab = "tracks" | "albums" | "artists";
+type Tab = "tracks" | "albums" | "artists" | "playlists";
 
 export default function LibraryPage() {
   const navigate = useNavigate();
   const { playNow, playNext, playLast, playNextAll, playLastAll } = useUploadPlayer();
   const [tab, setTab] = useState<Tab>("tracks");
-  const deleteUploadMutation = useDeleteUploadMutation();
-  const deleteAlbumMutation = useDeleteAlbumMutation();
 
-  // Track action sheet
-  const [sheetTrack, setSheetTrack] = useState<UploadedTrack | null>(null);
-  // Album action sheet
-  const [sheetAlbum, setSheetAlbum] = useState<UploadAlbum | null>(null);
+  const { data: creds } = useNavidromeCredentials();
+  const deleteTrack = useDeleteUploadByTrackIdMutation();
+  const deleteAlbum = useDeleteAlbumByIdMutation();
+  const createPlaylist = useCreatePlaylistMutation();
+  const renamePlaylist = useRenamePlaylistMutation();
+  const deletePlaylist = useDeletePlaylistMutation();
 
-  const tracksQuery = useInfiniteUploadsQuery();
-  const albumsQuery = useInfiniteUploadAlbumsQuery();
-  const artistsQuery = useInfiniteUploadArtistsQuery();
+  const [searchInput, setSearchInput] = useState("");
+  const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    const trimmed = searchInput.trim();
+    const timer = setTimeout(() => setSearchQuery(trimmed || undefined), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
-  const allTracks: UploadedTrack[] = useMemo(
+  // Action sheets
+  const [sheetSong, setSheetSong] = useState<NavidromeSong | null>(null);
+  const [sheetAlbum, setSheetAlbum] = useState<NavidromeAlbum | null>(null);
+  const [sheetPlaylist, setSheetPlaylist] = useState<NavidromePlaylist | null>(null);
+  const [addToPlaylistSongId, setAddToPlaylistSongId] = useState<string | null>(null);
+
+  const tracksQuery = useNavidromeTracksQuery(searchQuery);
+  const albumsQuery = useNavidromeAlbumsQuery(searchQuery);
+  const artistsQuery = useNavidromeArtistsQuery(searchQuery);
+  const playlistsQuery = useNavidromePlaylistsQuery();
+
+  const allSongs: NavidromeSong[] = useMemo(
     () => tracksQuery.data?.pages.flat() ?? [],
     [tracksQuery.data],
   );
-  const albums: UploadAlbum[] = useMemo(
+  const albums: NavidromeAlbum[] = useMemo(
     () => albumsQuery.data?.pages.flat() ?? [],
     [albumsQuery.data],
   );
-  const artists: UploadArtist[] = useMemo(
-    () => artistsQuery.data?.pages.flat() ?? [],
+  const artists: NavidromeArtist[] = useMemo(
+    () => artistsQuery.data ?? [],
     [artistsQuery.data],
+  );
+  const playlists: NavidromePlaylist[] = useMemo(
+    () => playlistsQuery.data ?? [],
+    [playlistsQuery.data],
   );
 
   const tracksSentinelRef = useInfiniteScrollSentinel(
@@ -240,35 +233,52 @@ export default function LibraryPage() {
     albumsQuery.isFetchingNextPage,
     albumsQuery.fetchNextPage,
   );
-  const artistsSentinelRef = useInfiniteScrollSentinel(
-    artistsQuery.hasNextPage ?? false,
-    artistsQuery.isFetchingNextPage,
-    artistsQuery.fetchNextPage,
-  );
 
-  const fetchSheetAlbumTracks = useCallback(async (): Promise<QueueTrack[]> => {
-    if (!sheetAlbum) return [];
-    const tracks = await getAlbumTracks(
-      sheetAlbum.albumUri ?? undefined,
-      sheetAlbum.albumUri ? undefined : sheetAlbum.albumArtist,
-      sheetAlbum.albumUri ? undefined : sheetAlbum.album,
-    );
-    return tracks.map(toQueueTrack);
-  }, [sheetAlbum]);
+  const coverUrl = useCallback(
+    (coverArt?: string) => (creds && coverArt ? getCoverArtUrl(creds, coverArt) : null),
+    [creds],
+  );
 
   const handleTrackPlay = useCallback(
-    (item: UploadedTrack) => {
-      const queue = allTracks.map(toQueueTrack);
-      const idx = allTracks.findIndex((t) => t.upload.id === item.upload.id);
+    (idx: number) => {
+      if (!creds) return;
+      const queue = allSongs.map((s) => songToQueueTrack(s, creds, coverUrl(s.coverArt)));
       playNow(queue, idx >= 0 ? idx : 0);
     },
-    [allTracks, playNow],
+    [allSongs, creds, coverUrl, playNow],
   );
+
+  const fetchAlbumTracks = useCallback(
+    async (album: NavidromeAlbum): Promise<QueueTrack[]> => {
+      if (!creds) return [];
+      const full = await fetchNavidromeAlbum(creds, album.id);
+      const art = coverUrl(full?.coverArt ?? album.coverArt);
+      return (full?.song ?? []).map((s) => songToQueueTrack(s, creds, art));
+    },
+    [creds, coverUrl],
+  );
+
+  const fetchPlaylistTracks = useCallback(
+    async (playlist: NavidromePlaylist): Promise<QueueTrack[]> => {
+      if (!creds) return [];
+      const full = await fetchNavidromePlaylist(creds, playlist.id);
+      return (full?.entry ?? []).map((s) => songToQueueTrack(s, creds, coverUrl(s.coverArt)));
+    },
+    [creds, coverUrl],
+  );
+
+  const handleCreatePlaylist = useCallback(async () => {
+    const name = window.prompt("New playlist name")?.trim();
+    if (!name) return;
+    await createPlaylist.mutateAsync({ name });
+  }, [createPlaylist]);
 
   const tabCls = (t: Tab) =>
     `flex-1 py-2.5 text-sm font-semibold border-none cursor-pointer transition-colors ${
       tab === t ? "border-b-2" : ""
     }`;
+
+  const tracksLoading = !creds || tracksQuery.isLoading;
 
   return (
     <Main>
@@ -286,9 +296,38 @@ export default function LibraryPage() {
         </Link>
       </div>
 
+      {/* Search */}
+      <div className="px-4 pb-2">
+        <div className="relative">
+          <span
+            className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            <IconSearch size={15} />
+          </span>
+          <input
+            type="text"
+            placeholder="Search your library…"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            className="w-full box-border py-2 pl-9 pr-9 rounded-xl text-sm outline-none border-none"
+            style={{ backgroundColor: "var(--color-menu-hover)", color: "var(--color-text)" }}
+          />
+          {searchInput && (
+            <button
+              onClick={() => setSearchInput("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 border-none bg-transparent cursor-pointer rounded-md flex items-center"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              <IconX size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+
       {/* Tabs */}
       <div className="flex border-b" style={{ borderColor: "var(--color-border)" }}>
-        {(["tracks", "albums", "artists"] as Tab[]).map((t) => (
+        {(["tracks", "albums", "artists", "playlists"] as Tab[]).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
@@ -309,31 +348,33 @@ export default function LibraryPage() {
       {/* Tracks tab */}
       {tab === "tracks" && (
         <div>
-          {tracksQuery.isLoading && Array.from({ length: 8 }).map((_, i) => <TrackSkeleton key={i} />)}
-          {!tracksQuery.isLoading && allTracks.length === 0 && (
+          {tracksLoading && Array.from({ length: 8 }).map((_, i) => <TrackSkeleton key={i} />)}
+          {!tracksLoading && allSongs.length === 0 && (
             <div className="flex flex-col items-center py-20 gap-4 px-4">
               <IconVinyl size={48} color="var(--color-text-muted)" />
               <p className="text-center m-0" style={{ color: "var(--color-text-muted)" }}>
-                Your library is empty. Upload music to get started.
+                {searchQuery ? `No results for "${searchQuery}"` : "Your library is empty. Upload music to get started."}
               </p>
-              <Link
-                to="/library/upload"
-                className="px-5 py-2.5 rounded-xl text-sm font-semibold no-underline"
-                style={{ backgroundColor: "var(--color-primary)", color: "#fff" }}
-              >
-                Upload music
-              </Link>
+              {!searchQuery && (
+                <Link
+                  to="/library/upload"
+                  className="px-5 py-2.5 rounded-xl text-sm font-semibold no-underline"
+                  style={{ backgroundColor: "var(--color-primary)", color: "#fff" }}
+                >
+                  Upload music
+                </Link>
+              )}
             </div>
           )}
-          {allTracks.map((item, idx) => (
+          {allSongs.map((song, idx) => (
             <div
-              key={item.upload.id}
+              key={song.id}
               className="flex items-center gap-3 px-4 py-2.5 active:opacity-70"
               style={{ borderBottom: "1px solid var(--color-border)" }}
-              onClick={() => handleTrackPlay(item)}
+              onClick={() => handleTrackPlay(idx)}
             >
               <span
-                className="w-6 text-right text-xs shrink-0 font-variant-numeric tabular-nums"
+                className="w-6 text-right text-xs shrink-0 tabular-nums"
                 style={{ color: "var(--color-text-muted)" }}
               >
                 {idx + 1}
@@ -342,27 +383,27 @@ export default function LibraryPage() {
                 className="w-10 h-10 rounded-lg shrink-0 overflow-hidden flex items-center justify-center"
                 style={{ backgroundColor: "var(--color-menu-hover)" }}
               >
-                {item.track.albumArt ? (
-                  <img src={item.track.albumArt} alt="" className="w-full h-full object-cover" />
+                {coverUrl(song.coverArt) ? (
+                  <img src={coverUrl(song.coverArt)!} alt="" className="w-full h-full object-cover" />
                 ) : (
                   <IconMusic size={16} color="var(--color-text-muted)" />
                 )}
               </div>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>
-                  {item.track.title}
+                  {song.title}
                 </p>
                 <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
-                  {item.track.artist}{item.track.album ? ` — ${item.track.album}` : ""}
+                  {song.artist}{song.album ? ` — ${song.album}` : ""}
                 </p>
               </div>
-              <span className="text-xs shrink-0 font-variant-numeric" style={{ color: "var(--color-text-muted)" }}>
-                {formatDuration(item.track.duration)}
+              <span className="text-xs shrink-0" style={{ color: "var(--color-text-muted)" }}>
+                {formatDuration(song.duration)}
               </span>
               <button
                 className="p-1.5 border-none bg-transparent cursor-pointer rounded-lg shrink-0"
                 style={{ color: "var(--color-text-muted)" }}
-                onClick={(e) => { e.stopPropagation(); setSheetTrack(item); }}
+                onClick={(e) => { e.stopPropagation(); setSheetSong(song); }}
               >
                 <IconDots size={16} />
               </button>
@@ -376,7 +417,7 @@ export default function LibraryPage() {
       {/* Albums tab */}
       {tab === "albums" && (
         <div className="px-4 pt-4">
-          {albumsQuery.isLoading && (
+          {(albumsQuery.isLoading || !creds) && (
             <div className="grid grid-cols-2 gap-4">
               {Array.from({ length: 6 }).map((_, i) => (
                 <ContentLoader
@@ -394,47 +435,43 @@ export default function LibraryPage() {
               ))}
             </div>
           )}
-          {!albumsQuery.isLoading && albums.length === 0 && (
+          {!albumsQuery.isLoading && creds && albums.length === 0 && (
             <div className="flex flex-col items-center py-20 gap-3">
               <IconVinyl size={48} color="var(--color-text-muted)" />
-              <p className="m-0 text-sm" style={{ color: "var(--color-text-muted)" }}>No albums yet</p>
+              <p className="m-0 text-sm" style={{ color: "var(--color-text-muted)" }}>
+                {searchQuery ? `No results for "${searchQuery}"` : "No albums yet"}
+              </p>
             </div>
           )}
-          {albums.length > 0 && (
+          {creds && albums.length > 0 && (
             <div className="grid grid-cols-2 gap-4 pb-6">
               {albums.map((alb) => {
-                const key = albumKey(alb.albumArtist, alb.album);
-                const parsed = parseAtUri(alb.albumUri);
+                const art = coverUrl(alb.coverArt);
                 return (
                   <div
-                    key={key}
+                    key={alb.id}
                     className="cursor-pointer"
-                    onClick={() => {
-                      if (parsed) navigate(`/library/${parsed.did}/album/${parsed.rkey}`);
-                    }}
+                    onClick={() => navigate(`/library/album/${alb.id}`)}
                   >
                     <div
                       className="w-full aspect-square rounded-xl overflow-hidden flex items-center justify-center mb-2 relative"
                       style={{ backgroundColor: "var(--color-menu-hover)" }}
                     >
-                      {alb.albumArt ? (
-                        <img src={alb.albumArt} alt={alb.album} className="w-full h-full object-cover" />
+                      {art ? (
+                        <img src={art} alt={alb.name} className="w-full h-full object-cover" />
                       ) : (
                         <IconVinyl size={40} color="var(--color-text-muted)" />
                       )}
                       <button
                         className="absolute bottom-2 right-2 w-9 h-9 rounded-full border-none flex items-center justify-center cursor-pointer"
                         style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setSheetAlbum(alb);
-                        }}
+                        onClick={(e) => { e.stopPropagation(); setSheetAlbum(alb); }}
                       >
                         <IconDots size={16} color="#fff" />
                       </button>
                     </div>
-                    <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{alb.album}</p>
-                    <p className="text-xs truncate m-0 mt-0.5" style={{ color: "var(--color-text-muted)" }}>{alb.albumArtist}</p>
+                    <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{alb.name}</p>
+                    <p className="text-xs truncate m-0 mt-0.5" style={{ color: "var(--color-text-muted)" }}>{alb.artist}</p>
                   </div>
                 );
               })}
@@ -447,7 +484,7 @@ export default function LibraryPage() {
       {/* Artists tab */}
       {tab === "artists" && (
         <div className="px-4 pt-4">
-          {artistsQuery.isLoading && (
+          {(artistsQuery.isLoading || !creds) && (
             <div className="grid grid-cols-2 gap-4">
               {Array.from({ length: 6 }).map((_, i) => (
                 <ContentLoader
@@ -464,88 +501,133 @@ export default function LibraryPage() {
               ))}
             </div>
           )}
-          {!artistsQuery.isLoading && artists.length === 0 && (
+          {!artistsQuery.isLoading && creds && artists.length === 0 && (
             <div className="flex flex-col items-center py-20 gap-3">
-              <IconMusic size={48} color="var(--color-text-muted)" />
-              <p className="m-0 text-sm" style={{ color: "var(--color-text-muted)" }}>No artists yet</p>
+              <IconUser size={48} color="var(--color-text-muted)" />
+              <p className="m-0 text-sm" style={{ color: "var(--color-text-muted)" }}>
+                {searchQuery ? `No results for "${searchQuery}"` : "No artists yet"}
+              </p>
             </div>
           )}
-          {artists.length > 0 && (
+          {creds && artists.length > 0 && (
             <div className="grid grid-cols-2 gap-4 pb-6">
-              {artists.map((art) => {
-                const parsed = parseAtUri(art.artistUri);
-                return (
+              {artists.map((art) => (
+                <div
+                  key={art.id}
+                  className="flex flex-col items-center gap-2 cursor-pointer py-2"
+                  onClick={() => navigate(`/library/artist/${art.id}`)}
+                >
                   <div
-                    key={art.name}
-                    className="flex flex-col items-center gap-2 cursor-pointer py-2"
-                    onClick={() => {
-                      if (parsed) navigate(`/library/${parsed.did}/artist/${parsed.rkey}`);
-                    }}
-                    style={{ opacity: parsed ? 1 : 0.5 }}
+                    className="w-16 h-16 rounded-full overflow-hidden shrink-0 flex items-center justify-center text-2xl font-bold"
+                    style={{ backgroundColor: "var(--color-menu-hover)", color: "var(--color-text-muted)" }}
                   >
-                    <ArtistAvatar artistUri={art.artistUri} name={art.name} />
-                    <p className="text-sm font-semibold text-center truncate m-0 w-full px-2" style={{ color: "var(--color-text)" }}>
-                      {art.name}
-                    </p>
-                    <p className="text-xs text-center m-0" style={{ color: "var(--color-text-muted)" }}>
-                      {art.albumCount} album{art.albumCount !== 1 ? "s" : ""}
-                    </p>
+                    {art.artistImageUrl ? (
+                      <img src={art.artistImageUrl} alt={art.name} className="w-full h-full object-cover" />
+                    ) : (
+                      art.name.charAt(0).toUpperCase()
+                    )}
                   </div>
-                );
-              })}
+                  <p className="text-sm font-semibold text-center truncate m-0 w-full px-2" style={{ color: "var(--color-text)" }}>
+                    {art.name}
+                  </p>
+                  <p className="text-xs text-center m-0" style={{ color: "var(--color-text-muted)" }}>
+                    {art.albumCount} album{art.albumCount !== 1 ? "s" : ""}
+                  </p>
+                </div>
+              ))}
             </div>
           )}
-          <div ref={artistsSentinelRef} />
+        </div>
+      )}
+
+      {/* Playlists tab */}
+      {tab === "playlists" && (
+        <div className="px-4 pt-4">
+          <button
+            onClick={handleCreatePlaylist}
+            className="w-full flex items-center justify-center gap-2 py-2.5 mb-4 rounded-xl border-none cursor-pointer text-sm font-semibold"
+            style={{ backgroundColor: "var(--color-menu-hover)", color: "var(--color-primary)" }}
+          >
+            <IconPlus size={16} /> New playlist
+          </button>
+          {(playlistsQuery.isLoading || !creds) && (
+            Array.from({ length: 5 }).map((_, i) => <TrackSkeleton key={i} />)
+          )}
+          {!playlistsQuery.isLoading && creds && playlists.length === 0 && (
+            <div className="flex flex-col items-center py-16 gap-3">
+              <IconPlaylist size={48} color="var(--color-text-muted)" />
+              <p className="m-0 text-sm" style={{ color: "var(--color-text-muted)" }}>No playlists yet</p>
+            </div>
+          )}
+          {creds && playlists.map((pl) => (
+            <div
+              key={pl.id}
+              className="flex items-center gap-3 py-3 active:opacity-70"
+              style={{ borderBottom: "1px solid var(--color-border)" }}
+              onClick={() => navigate(`/library/playlist/${pl.id}`)}
+            >
+              <div
+                className="w-10 h-10 rounded-lg shrink-0 overflow-hidden flex items-center justify-center"
+                style={{ backgroundColor: "var(--color-menu-hover)" }}
+              >
+                {coverUrl(pl.coverArt) ? (
+                  <img src={coverUrl(pl.coverArt)!} alt="" className="w-full h-full object-cover" />
+                ) : (
+                  <IconPlaylist size={18} color="var(--color-text-muted)" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{pl.name}</p>
+                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
+                  {pl.songCount} track{pl.songCount !== 1 ? "s" : ""}
+                </p>
+              </div>
+              <button
+                className="p-1.5 border-none bg-transparent cursor-pointer rounded-lg shrink-0"
+                style={{ color: "var(--color-text-muted)" }}
+                onClick={(e) => { e.stopPropagation(); setSheetPlaylist(pl); }}
+              >
+                <IconDots size={16} />
+              </button>
+            </div>
+          ))}
         </div>
       )}
 
       {/* Track action sheet */}
-      <ActionSheet open={!!sheetTrack} onClose={() => setSheetTrack(null)}>
-        {sheetTrack && (
+      <ActionSheet open={!!sheetSong} onClose={() => setSheetSong(null)}>
+        {sheetSong && creds && (
           <>
             <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
               <div className="w-10 h-10 rounded-lg overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)" }}>
-                {sheetTrack.track.albumArt
-                  ? <img src={sheetTrack.track.albumArt} alt="" className="w-full h-full object-cover" />
+                {coverUrl(sheetSong.coverArt)
+                  ? <img src={coverUrl(sheetSong.coverArt)!} alt="" className="w-full h-full object-cover" />
                   : <IconMusic size={16} color="var(--color-text-muted)" />}
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetTrack.track.title}</p>
-                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetTrack.track.artist}</p>
+                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetSong.title}</p>
+                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetSong.artist}</p>
               </div>
             </div>
-            <SheetItem icon={<IconPlayerPlay size={16} />} label="Play" onClick={() => { handleTrackPlay(sheetTrack); setSheetTrack(null); }} />
-            <SheetItem label="Play next" onClick={() => { playNext(toQueueTrack(sheetTrack)); setSheetTrack(null); }} />
-            <SheetItem label="Add to queue" onClick={() => { playLast(toQueueTrack(sheetTrack)); setSheetTrack(null); }} />
-            {parseAtUri(sheetTrack.track.albumUri) && (
-              <SheetItem label="Go to album" onClick={() => {
-                const p = parseAtUri(sheetTrack.track.albumUri)!;
-                navigate(`/library/${p.did}/album/${p.rkey}`);
-                setSheetTrack(null);
-              }} />
+            <SheetItem icon={<IconPlayerPlay size={16} />} label="Play" onClick={() => { const i = allSongs.findIndex((s) => s.id === sheetSong.id); handleTrackPlay(i); setSheetSong(null); }} />
+            <SheetItem label="Play next" onClick={() => { playNext(songToQueueTrack(sheetSong, creds, coverUrl(sheetSong.coverArt))); setSheetSong(null); }} />
+            <SheetItem label="Add to queue" onClick={() => { playLast(songToQueueTrack(sheetSong, creds, coverUrl(sheetSong.coverArt))); setSheetSong(null); }} />
+            <SheetItem icon={<IconPlaylist size={16} />} label="Add to playlist" onClick={() => { setAddToPlaylistSongId(sheetSong.id); setSheetSong(null); }} />
+            {sheetSong.albumId && (
+              <SheetItem label="Go to album" onClick={() => { navigate(`/library/album/${sheetSong.albumId}`); setSheetSong(null); }} />
             )}
-            {parseAtUri(sheetTrack.track.artistUri) && (
-              <SheetItem label="Go to artist" onClick={() => {
-                const p = parseAtUri(sheetTrack.track.artistUri)!;
-                navigate(`/library/${p.did}/artist/${p.rkey}`);
-                setSheetTrack(null);
-              }} />
+            {sheetSong.artistId && (
+              <SheetItem label="Go to artist" onClick={() => { navigate(`/library/artist/${sheetSong.artistId}`); setSheetSong(null); }} />
             )}
             <SheetItem
               icon={<IconTrash size={16} />}
               label="Delete track"
               danger
-              disabled={deleteUploadMutation.isPending}
+              disabled={deleteTrack.isPending}
               onClick={() => {
-                if (
-                  !window.confirm(
-                    `Delete "${sheetTrack.track.title}" from your library? This cannot be undone.`,
-                  )
-                ) {
-                  return;
-                }
-                deleteUploadMutation.mutate(sheetTrack.upload.id);
-                setSheetTrack(null);
+                if (!window.confirm(`Delete "${sheetSong.title}" from your library? This cannot be undone.`)) return;
+                deleteTrack.mutate(sheetSong.id);
+                setSheetSong(null);
               }}
             />
           </>
@@ -558,50 +640,81 @@ export default function LibraryPage() {
           <>
             <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
               <div className="w-10 h-10 rounded-lg overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)" }}>
-                {sheetAlbum.albumArt
-                  ? <img src={sheetAlbum.albumArt} alt="" className="w-full h-full object-cover" />
+                {coverUrl(sheetAlbum.coverArt)
+                  ? <img src={coverUrl(sheetAlbum.coverArt)!} alt="" className="w-full h-full object-cover" />
                   : <IconVinyl size={16} color="var(--color-text-muted)" />}
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetAlbum.album}</p>
-                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetAlbum.albumArtist}</p>
+                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetAlbum.name}</p>
+                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetAlbum.artist}</p>
               </div>
             </div>
-            <SheetItem icon={<IconPlayerPlay size={16} />} label="Play" onClick={async () => { const t = await fetchSheetAlbumTracks(); playNow(t); setSheetAlbum(null); }} />
-            <SheetItem icon={<IconArrowsShuffle size={16} />} label="Shuffle" onClick={async () => { const t = await fetchSheetAlbumTracks(); playNow([...t].sort(() => Math.random() - 0.5)); setSheetAlbum(null); }} />
-            <SheetItem label="Play next" onClick={async () => { const t = await fetchSheetAlbumTracks(); playNextAll(t); setSheetAlbum(null); }} />
-            <SheetItem label="Add to queue" onClick={async () => { const t = await fetchSheetAlbumTracks(); playLastAll(t); setSheetAlbum(null); }} />
-            {sheetAlbum.artistUri && parseAtUri(sheetAlbum.artistUri) && (
-              <SheetItem label="Go to artist" onClick={() => {
-                const p = parseAtUri(sheetAlbum.artistUri!)!;
-                navigate(`/library/${p.did}/artist/${p.rkey}`);
-                setSheetAlbum(null);
-              }} />
+            <SheetItem icon={<IconPlayerPlay size={16} />} label="Play" onClick={async () => { const t = await fetchAlbumTracks(sheetAlbum); playNow(t); setSheetAlbum(null); }} />
+            <SheetItem icon={<IconArrowsShuffle size={16} />} label="Shuffle" onClick={async () => { const t = await fetchAlbumTracks(sheetAlbum); playNow([...t].sort(() => Math.random() - 0.5)); setSheetAlbum(null); }} />
+            <SheetItem label="Play next" onClick={async () => { const t = await fetchAlbumTracks(sheetAlbum); playNextAll(t); setSheetAlbum(null); }} />
+            <SheetItem label="Add to queue" onClick={async () => { const t = await fetchAlbumTracks(sheetAlbum); playLastAll(t); setSheetAlbum(null); }} />
+            {sheetAlbum.artistId && (
+              <SheetItem label="Go to artist" onClick={() => { navigate(`/library/artist/${sheetAlbum.artistId}`); setSheetAlbum(null); }} />
             )}
             <SheetItem
               icon={<IconTrash size={16} />}
               label="Delete album"
               danger
-              disabled={deleteAlbumMutation.isPending}
+              disabled={deleteAlbum.isPending}
               onClick={() => {
-                if (
-                  !window.confirm(
-                    `Delete every track from "${sheetAlbum.album}" by ${sheetAlbum.albumArtist}? This cannot be undone.`,
-                  )
-                ) {
-                  return;
-                }
-                deleteAlbumMutation.mutate(
-                  sheetAlbum.albumUri
-                    ? { albumUri: sheetAlbum.albumUri }
-                    : { albumArtist: sheetAlbum.albumArtist, albumName: sheetAlbum.album },
-                );
+                if (!window.confirm(`Delete every track from "${sheetAlbum.name}" by ${sheetAlbum.artist}? This cannot be undone.`)) return;
+                deleteAlbum.mutate(sheetAlbum.id);
                 setSheetAlbum(null);
               }}
             />
           </>
         )}
       </ActionSheet>
+
+      {/* Playlist action sheet */}
+      <ActionSheet open={!!sheetPlaylist} onClose={() => setSheetPlaylist(null)}>
+        {sheetPlaylist && (
+          <>
+            <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+              <div className="w-10 h-10 rounded-lg overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)" }}>
+                <IconPlaylist size={18} color="var(--color-text-muted)" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetPlaylist.name}</p>
+                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetPlaylist.songCount} tracks</p>
+              </div>
+            </div>
+            <SheetItem icon={<IconPlayerPlay size={16} />} label="Play" onClick={async () => { const t = await fetchPlaylistTracks(sheetPlaylist); playNow(t); setSheetPlaylist(null); }} />
+            <SheetItem icon={<IconArrowsShuffle size={16} />} label="Shuffle" onClick={async () => { const t = await fetchPlaylistTracks(sheetPlaylist); playNow([...t].sort(() => Math.random() - 0.5)); setSheetPlaylist(null); }} />
+            <SheetItem
+              label="Rename"
+              onClick={async () => {
+                const name = window.prompt("Rename playlist", sheetPlaylist.name)?.trim();
+                if (name && name !== sheetPlaylist.name) await renamePlaylist.mutateAsync({ id: sheetPlaylist.id, name });
+                setSheetPlaylist(null);
+              }}
+            />
+            <SheetItem
+              icon={<IconTrash size={16} />}
+              label="Delete playlist"
+              danger
+              disabled={deletePlaylist.isPending}
+              onClick={() => {
+                if (!window.confirm(`Delete playlist "${sheetPlaylist.name}"? This cannot be undone.`)) return;
+                deletePlaylist.mutate(sheetPlaylist.id);
+                setSheetPlaylist(null);
+              }}
+            />
+          </>
+        )}
+      </ActionSheet>
+
+      {/* Add-to-playlist sheet */}
+      <AddToPlaylistSheet
+        open={!!addToPlaylistSongId}
+        songId={addToPlaylistSongId}
+        onClose={() => setAddToPlaylistSongId(null)}
+      />
     </Main>
   );
 }

--- a/apps/web-mobile/src/pages/library/playlist.tsx
+++ b/apps/web-mobile/src/pages/library/playlist.tsx
@@ -1,0 +1,253 @@
+import {
+  IconArrowLeft,
+  IconArrowsShuffle,
+  IconDots,
+  IconMusic,
+  IconPlayerPlay,
+  IconPlaylist,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import ContentLoader from "react-content-loader";
+import { getCoverArtUrl, type NavidromeSong } from "../../api/navidrome";
+import type { QueueTrack } from "../../atoms/queue";
+import {
+  useNavidromeCredentials,
+  useNavidromePlaylistQuery,
+  useRemoveTrackFromPlaylistMutation,
+  songToQueueTrack,
+} from "../../hooks/useNavidrome";
+import { useUploadPlayer } from "../../hooks/useUploadPlayer";
+import AddToPlaylistSheet from "../../components/AddToPlaylistSheet";
+import Main from "../../layouts/Main";
+
+function formatDuration(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function formatTotalDuration(seconds: number) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h} hr ${m} min`;
+  return `${m} min`;
+}
+
+function ActionSheet({ open, onClose, children }: { open: boolean; onClose: () => void; children: React.ReactNode }) {
+  if (!open) return null;
+  return (
+    <>
+      <div className="fixed inset-0 z-40" style={{ backgroundColor: "rgba(0,0,0,0.5)" }} onClick={onClose} />
+      <div className="fixed left-0 right-0 bottom-0 z-50 rounded-t-2xl" style={{ backgroundColor: "var(--color-surface)", borderTop: "1px solid var(--color-border)" }}>
+        <div className="flex justify-center pt-2 pb-1">
+          <div className="w-10 h-1 rounded-full" style={{ backgroundColor: "var(--color-border)" }} />
+        </div>
+        {children}
+        <button onClick={onClose} className="w-full py-4 text-center border-none bg-transparent cursor-pointer text-sm font-semibold" style={{ color: "var(--color-text-muted)", borderTop: "1px solid var(--color-border)" }}>
+          Cancel
+        </button>
+      </div>
+    </>
+  );
+}
+
+function SheetItem({ label, onClick, icon, danger, disabled }: { label: string; onClick: () => void; icon?: React.ReactNode; danger?: boolean; disabled?: boolean }) {
+  const color = danger ? "#e55" : "var(--color-text)";
+  return (
+    <button onClick={onClick} disabled={disabled} className="w-full flex items-center gap-3 px-5 py-3.5 border-none bg-transparent cursor-pointer text-left text-sm font-medium disabled:opacity-50" style={{ color }}>
+      {icon && <span style={{ color: danger ? "#e55" : "var(--color-text-muted)" }}>{icon}</span>}
+      {label}
+    </button>
+  );
+}
+
+export default function LibraryPlaylistPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const { playNow, playNext, playLast } = useUploadPlayer();
+  const { data: creds } = useNavidromeCredentials();
+  const { data: playlist, isLoading } = useNavidromePlaylistQuery(id ?? "");
+  const removeTrack = useRemoveTrackFromPlaylistMutation();
+
+  const [sheetIdx, setSheetIdx] = useState<number | null>(null);
+  const [addToPlaylistSongId, setAddToPlaylistSongId] = useState<string | null>(null);
+
+  const songs: NavidromeSong[] = useMemo(() => playlist?.entry ?? [], [playlist]);
+  const totalDuration = playlist?.duration ?? songs.reduce((sum, s) => sum + s.duration, 0);
+
+  const coverUrl = useCallback(
+    (coverArt?: string) => (creds && coverArt ? getCoverArtUrl(creds, coverArt) : null),
+    [creds],
+  );
+
+  const queue = useCallback(
+    (): QueueTrack[] => (creds ? songs.map((s) => songToQueueTrack(s, creds, coverUrl(s.coverArt))) : []),
+    [creds, songs, coverUrl],
+  );
+
+  const handlePlay = useCallback(() => playNow(queue()), [queue, playNow]);
+  const handleShuffle = useCallback(() => playNow([...queue()].sort(() => Math.random() - 0.5)), [queue, playNow]);
+  const handleTrackPlay = useCallback((idx: number) => playNow(queue(), idx), [queue, playNow]);
+
+  const sheetSong = sheetIdx != null ? songs[sheetIdx] : null;
+
+  if (isLoading || !creds || !playlist) {
+    return (
+      <Main>
+        <div className="px-4 pt-4">
+          <button onClick={() => navigate("/library")} className="flex items-center gap-1 text-sm border-none bg-transparent cursor-pointer p-0 mb-4" style={{ color: "var(--color-text-muted)" }}>
+            <IconArrowLeft size={16} /> Library
+          </button>
+          <ContentLoader width="100%" height={200} viewBox="0 0 360 200" backgroundColor="var(--color-skeleton-background)" foregroundColor="var(--color-skeleton-foreground)">
+            <rect x="0" y="0" rx="16" ry="16" width="120" height="120" />
+            <rect x="136" y="16" rx="6" ry="6" width="180" height="20" />
+            <rect x="136" y="46" rx="4" ry="4" width="120" height="14" />
+          </ContentLoader>
+        </div>
+      </Main>
+    );
+  }
+
+  return (
+    <Main>
+      <div className="px-4 pt-4 pb-32">
+        <button
+          onClick={() => navigate("/library")}
+          className="flex items-center gap-1 text-sm border-none bg-transparent cursor-pointer p-0 mb-4"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          <IconArrowLeft size={16} /> Library
+        </button>
+
+        {/* Header */}
+        <div className="flex gap-4 items-end mb-6">
+          <div className="w-32 h-32 rounded-2xl overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)", boxShadow: "0 8px 32px rgba(0,0,0,0.2)" }}>
+            {coverUrl(playlist.coverArt) ? (
+              <img src={coverUrl(playlist.coverArt)!} alt={playlist.name} className="w-full h-full object-cover" />
+            ) : (
+              <IconPlaylist size={48} color="var(--color-text-muted)" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0 pb-1">
+            <h1 className="text-lg font-bold m-0 mb-1 leading-tight" style={{ color: "var(--color-text)", fontFamily: "RockfordSansBold" }}>
+              {playlist.name}
+            </h1>
+            <p className="text-xs m-0 mb-3" style={{ color: "var(--color-text-muted)" }}>
+              {songs.length} track{songs.length !== 1 ? "s" : ""} · {formatTotalDuration(totalDuration)}
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={handlePlay}
+                disabled={songs.length === 0}
+                className="flex items-center gap-2 px-5 py-2 rounded-full border-none cursor-pointer text-sm font-semibold disabled:opacity-50"
+                style={{ backgroundColor: "var(--color-text)", color: "var(--color-background)" }}
+              >
+                <IconPlayerPlay size={14} /> Play
+              </button>
+              <button
+                onClick={handleShuffle}
+                disabled={songs.length === 0}
+                className="flex items-center gap-2 px-4 py-2 rounded-full border-none cursor-pointer text-sm font-semibold bg-transparent disabled:opacity-50"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                <IconArrowsShuffle size={14} /> Shuffle
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Track list */}
+        {songs.length === 0 ? (
+          <p className="text-center text-sm py-16 m-0" style={{ color: "var(--color-text-muted)" }}>
+            This playlist is empty.
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {songs.map((song, idx) => (
+              <div
+                key={`${song.id}-${idx}`}
+                className="flex items-center gap-3 py-3 active:opacity-70"
+                style={{ borderBottom: "1px solid var(--color-border)" }}
+                onClick={() => handleTrackPlay(idx)}
+              >
+                <div
+                  className="w-10 h-10 rounded-lg shrink-0 overflow-hidden flex items-center justify-center"
+                  style={{ backgroundColor: "var(--color-menu-hover)" }}
+                >
+                  {coverUrl(song.coverArt) ? (
+                    <img src={coverUrl(song.coverArt)!} alt="" className="w-full h-full object-cover" />
+                  ) : (
+                    <IconMusic size={16} color="var(--color-text-muted)" />
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{song.title}</p>
+                  <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>
+                    {song.artist}{song.album ? ` — ${song.album}` : ""}
+                  </p>
+                </div>
+                <span className="text-xs shrink-0" style={{ color: "var(--color-text-muted)" }}>
+                  {formatDuration(song.duration)}
+                </span>
+                <button
+                  className="p-1.5 border-none bg-transparent cursor-pointer rounded-lg shrink-0"
+                  style={{ color: "var(--color-text-muted)" }}
+                  onClick={(e) => { e.stopPropagation(); setSheetIdx(idx); }}
+                >
+                  <IconDots size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Track action sheet */}
+      <ActionSheet open={sheetIdx != null} onClose={() => setSheetIdx(null)}>
+        {sheetSong && creds && (
+          <>
+            <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+              <div className="w-10 h-10 rounded-lg overflow-hidden shrink-0 flex items-center justify-center" style={{ backgroundColor: "var(--color-menu-hover)" }}>
+                {coverUrl(sheetSong.coverArt)
+                  ? <img src={coverUrl(sheetSong.coverArt)!} alt="" className="w-full h-full object-cover" />
+                  : <IconMusic size={16} color="var(--color-text-muted)" />}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold truncate m-0" style={{ color: "var(--color-text)" }}>{sheetSong.title}</p>
+                <p className="text-xs truncate m-0" style={{ color: "var(--color-text-muted)" }}>{sheetSong.artist}</p>
+              </div>
+            </div>
+            <SheetItem label="Play" onClick={() => { handleTrackPlay(sheetIdx!); setSheetIdx(null); }} />
+            <SheetItem label="Play next" onClick={() => { playNext(songToQueueTrack(sheetSong, creds, coverUrl(sheetSong.coverArt))); setSheetIdx(null); }} />
+            <SheetItem label="Add to queue" onClick={() => { playLast(songToQueueTrack(sheetSong, creds, coverUrl(sheetSong.coverArt))); setSheetIdx(null); }} />
+            <SheetItem icon={<IconPlaylist size={16} />} label="Add to playlist" onClick={() => { setAddToPlaylistSongId(sheetSong.id); setSheetIdx(null); }} />
+            {sheetSong.albumId && (
+              <SheetItem label="Go to album" onClick={() => { navigate(`/library/album/${sheetSong.albumId}`); setSheetIdx(null); }} />
+            )}
+            {sheetSong.artistId && (
+              <SheetItem label="Go to artist" onClick={() => { navigate(`/library/artist/${sheetSong.artistId}`); setSheetIdx(null); }} />
+            )}
+            <SheetItem
+              icon={<IconTrash size={16} />}
+              label="Remove from playlist"
+              danger
+              disabled={removeTrack.isPending}
+              onClick={() => {
+                removeTrack.mutate({ playlistId: playlist.id, index: sheetIdx! });
+                setSheetIdx(null);
+              }}
+            />
+          </>
+        )}
+      </ActionSheet>
+
+      <AddToPlaylistSheet
+        open={!!addToPlaylistSongId}
+        songId={addToPlaylistSongId}
+        onClose={() => setAddToPlaylistSongId(null)}
+      />
+    </Main>
+  );
+}

--- a/apps/web/src/components/ScrobblesAreaChart/ScrobblesAreaChart.tsx
+++ b/apps/web/src/components/ScrobblesAreaChart/ScrobblesAreaChart.tsx
@@ -118,7 +118,10 @@ function ScrobblesAreaChart() {
 
   return (
     <>
-      {!pathname.includes("/playlist/") && (
+      {/* Public playlist pages (/$did/playlist/$rkey) hide the chart; library
+          pages — including /library/playlist/$id — keep the overall Scrobble
+          Stats like the rest of the library. */}
+      {(!pathname.includes("/playlist/") || pathname.startsWith("/library")) && (
         <>
           <LabelMedium
             marginBottom={"10px"}

--- a/bun.lock
+++ b/bun.lock
@@ -270,7 +270,7 @@
         "react-hook-form": "^7.54.2",
         "react-router-dom": "^7.6.3",
         "recharts": "^2.15.1",
-        "rockbox-wasm": "^0.1.8",
+        "rockbox-wasm": "^0.1.9",
         "styletron-engine-monolithic": "^1.0.0",
         "styletron-react": "^6.1.1",
         "tailwindcss": "^4.0.0",
@@ -3713,8 +3713,6 @@
     "@rocksky/web-mobile/@types/ramda": ["@types/ramda@0.29.12", "", { "dependencies": { "types-ramda": "^0.29.10" } }, "sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA=="],
 
     "@rocksky/web-mobile/ramda": ["ramda@0.29.1", "", {}, "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA=="],
-
-    "@rocksky/web-mobile/rockbox-wasm": ["rockbox-wasm@0.1.8", "", {}, "sha512-h5kWS3jMttxtCklUN36vGz5BBvYNDZFyDjgOGyAKTs9kz3W/86UsDJ37IZF8NEj9GekbzOjTe09Pc2TD/xhF1A=="],
 
     "@rocksky/web-mobile/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 


### PR DESCRIPTION
… & media session

web-mobile:
- Browse uploaded tracks/albums/artists via the Navidrome (Subsonic) API instead of the /uploads endpoints, matching the desktop app. Fixes broken infinite scroll (albums/artists observer never attached on tab switch) and album/artist detail pages missing tracks (the /uploads endpoint caps size at 200, so client-side filtering dropped everything past the first 200 uploads).
- Add a Playlists tab with full CRUD (create/rename/delete, add/remove tracks, play/shuffle) and library search.
- Add "Add to playlist" to every track context menu (shared AddToPlaylistSheet).
- Fix equalizer popup rendering behind the full-screen player (z-index tie).
- Fix Media Session: start the silent <audio> anchor inside the play gesture so OS/lock-screen controls actually surface (autoplay policy blocked the old effect-driven start).
- Routes: /library/{album,artist,playlist}/:id (Navidrome ids).

web (desktop):
- Navidrome playlist API + hooks (CRUD) for the upcoming desktop playlists tab.
- Keep the Scrobble Stats sidebar on /library/playlist/:id (only public playlist pages hide it).