### PR TITLE
feat(shoutbox): add GIF/sticker/clip media + @mention & link support

### DIFF
--- a/.tangled/workflows/deploy-web.yml
+++ b/.tangled/workflows/deploy-web.yml
@@ -25,6 +25,7 @@ steps:
       echo 'VITE_PUBLIC_URL=https://rocksky.app' >> .env.prod
       echo 'VITE_ROCKBOX_URL=https://rockbox.rocksky.app' >> .env.prod
       echo 'VITE_PUBLIC_POSTHOG_KEY=phc_erMjlNEGNOSKX6dXBZne7k4PuUWqM4Bw4EuQxdcaSd5' >> .env.prod
+      echo "VITE_KLIPY_API_KEY=$KLIPY_API_KEY" >> .env.prod
       bun run build:prod
 
   - name: deploy to cloudflare

--- a/apps/api/drizzle/0016_shouts_gif.sql
+++ b/apps/api/drizzle/0016_shouts_gif.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "shouts" ADD COLUMN IF NOT EXISTS "gif_url" text;--> statement-breakpoint
+ALTER TABLE "shouts" ADD COLUMN IF NOT EXISTS "gif_preview_url" text;--> statement-breakpoint
+ALTER TABLE "shouts" ADD COLUMN IF NOT EXISTS "gif_alt" text;--> statement-breakpoint
+ALTER TABLE "shouts" ADD COLUMN IF NOT EXISTS "gif_width" integer;--> statement-breakpoint
+ALTER TABLE "shouts" ADD COLUMN IF NOT EXISTS "gif_height" integer;

--- a/apps/api/drizzle/0017_shouts_facets.sql
+++ b/apps/api/drizzle/0017_shouts_facets.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "shouts" ADD COLUMN IF NOT EXISTS "facets" jsonb;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -99,6 +99,20 @@
 			"when": 1780700000000,
 			"tag": "0015_navidrome_playlists",
 			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1780800000000,
+			"tag": "0016_shouts_gif",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1780800100000,
+			"tag": "0017_shouts_facets",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/lexicons/shout/defs.json
+++ b/apps/api/lexicons/shout/defs.json
@@ -54,6 +54,79 @@
           "type": "ref",
           "description": "The author of the shout.",
           "ref": "app.rocksky.shout.defs#author"
+        },
+        "gif": {
+          "type": "ref",
+          "description": "An attached GIF, sticker, or clip.",
+          "ref": "app.rocksky.shout.defs#gif"
+        },
+        "facets": {
+          "type": "array",
+          "description": "Mentions of other actors within the message, anchored to UTF-8 byte ranges.",
+          "items": {
+            "type": "ref",
+            "ref": "app.rocksky.shout.defs#mention"
+          }
+        }
+      }
+    },
+    "mention": {
+      "type": "object",
+      "description": "A mention of another actor within the shout message, anchored to a UTF-8 byte range in the message.",
+      "required": [
+        "did",
+        "byteStart",
+        "byteEnd"
+      ],
+      "properties": {
+        "did": {
+          "type": "string",
+          "description": "The DID of the mentioned actor.",
+          "format": "did"
+        },
+        "byteStart": {
+          "type": "integer",
+          "description": "Inclusive UTF-8 byte offset of the mention start.",
+          "minimum": 0
+        },
+        "byteEnd": {
+          "type": "integer",
+          "description": "Exclusive UTF-8 byte offset of the mention end.",
+          "minimum": 0
+        }
+      }
+    },
+    "gif": {
+      "type": "object",
+      "description": "A GIF, sticker, or clip embedded in a shout. `url` may point at an image (GIF/WebP) or a video (MP4); the client decides how to render it from the file extension.",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Direct URL of the animated GIF/MP4.",
+          "format": "uri"
+        },
+        "previewUrl": {
+          "type": "string",
+          "description": "Smaller still/preview image URL.",
+          "format": "uri"
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alternative text describing the media.",
+          "maxLength": 512
+        },
+        "width": {
+          "type": "integer",
+          "description": "The intrinsic width of the media in pixels.",
+          "minimum": 0
+        },
+        "height": {
+          "type": "integer",
+          "description": "The intrinsic height of the media in pixels.",
+          "minimum": 0
         }
       }
     }

--- a/apps/api/lexicons/shout/shout.json
+++ b/apps/api/lexicons/shout/shout.json
@@ -9,15 +9,13 @@
       "record": {
         "type": "object",
         "required": [
-          "message",
           "createdAt",
           "subject"
         ],
         "properties": {
           "message": {
             "type": "string",
-            "description": "The message of the shout.",
-            "minLength": 1,
+            "description": "The message of the shout. Optional when a gif/sticker/clip is attached.",
             "maxLength": 1000
           },
           "createdAt": {
@@ -32,6 +30,19 @@
           "subject": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef"
+          },
+          "gif": {
+            "type": "ref",
+            "description": "An attached GIF, sticker, or clip (e.g. from KLIPY).",
+            "ref": "app.rocksky.shout.defs#gif"
+          },
+          "facets": {
+            "type": "array",
+            "description": "Mentions of other actors within the message, anchored to UTF-8 byte ranges.",
+            "items": {
+              "type": "ref",
+              "ref": "app.rocksky.shout.defs#mention"
+            }
           }
         }
       }

--- a/apps/api/pkl/defs/shout/defs.pkl
+++ b/apps/api/pkl/defs/shout/defs.pkl
@@ -64,6 +64,81 @@ defs = new Mapping<String, ObjectType> {
         description = "The author of the shout."
         ref = "app.rocksky.shout.defs#author"
       }
+
+      ["gif"] = new Ref {
+        type = "ref"
+        description = "An attached GIF, sticker, or clip."
+        ref = "app.rocksky.shout.defs#gif"
+      }
+
+      ["facets"] = new Array {
+        type = "array"
+        description = "Mentions of other actors within the message, anchored to UTF-8 byte ranges."
+        items = new Ref {
+          type = "ref"
+          ref = "app.rocksky.shout.defs#mention"
+        }
+      }
+    }
+  }
+  ["mention"] {
+    type = "object"
+    description = "A mention of another actor within the shout message, anchored to a UTF-8 byte range in the message."
+    required = List("did", "byteStart", "byteEnd")
+    properties {
+      ["did"] = new StringType {
+        type = "string"
+        format = "did"
+        description = "The DID of the mentioned actor."
+      }
+
+      ["byteStart"] = new IntegerType {
+        type = "integer"
+        minimum = 0
+        description = "Inclusive UTF-8 byte offset of the mention start."
+      }
+
+      ["byteEnd"] = new IntegerType {
+        type = "integer"
+        minimum = 0
+        description = "Exclusive UTF-8 byte offset of the mention end."
+      }
+    }
+  }
+  ["gif"] {
+    type = "object"
+    description = "A GIF, sticker, or clip embedded in a shout. `url` may point at an image (GIF/WebP) or a video (MP4); the client decides how to render it from the file extension."
+    required = List("url")
+    properties {
+      ["url"] = new StringType {
+        type = "string"
+        format = "uri"
+        description = "Direct URL of the animated GIF/MP4."
+      }
+
+      ["previewUrl"] = new StringType {
+        type = "string"
+        format = "uri"
+        description = "Smaller still/preview image URL."
+      }
+
+      ["alt"] = new StringType {
+        type = "string"
+        maxLength = 512
+        description = "Alternative text describing the media."
+      }
+
+      ["width"] = new IntegerType {
+        type = "integer"
+        minimum = 0
+        description = "The intrinsic width of the media in pixels."
+      }
+
+      ["height"] = new IntegerType {
+        type = "integer"
+        minimum = 0
+        description = "The intrinsic height of the media in pixels."
+      }
     }
   }
 }

--- a/apps/api/pkl/defs/shout/shout.pkl
+++ b/apps/api/pkl/defs/shout/shout.pkl
@@ -9,12 +9,11 @@ defs = new Mapping<String, Record> {
     description = "A declaration of a shout."
     `record` {
       type = "object"
-      required = List("message", "createdAt", "subject")
+      required = List("createdAt", "subject")
       properties {
         ["message"] = new StringType {
           type = "string"
-          description = "The message of the shout."
-          minLength = 1
+          description = "The message of the shout. Optional when a gif/sticker/clip is attached."
           maxLength = 1000
         }
 
@@ -32,6 +31,21 @@ defs = new Mapping<String, Record> {
         ["subject"] = new Ref {
           type = "ref"
           ref = "com.atproto.repo.strongRef"
+        }
+
+        ["gif"] = new Ref {
+          type = "ref"
+          description = "An attached GIF, sticker, or clip (e.g. from KLIPY)."
+          ref = "app.rocksky.shout.defs#gif"
+        }
+
+        ["facets"] = new Array {
+          type = "array"
+          description = "Mentions of other actors within the message, anchored to UTF-8 byte ranges."
+          items = new Ref {
+            type = "ref"
+            ref = "app.rocksky.shout.defs#mention"
+          }
         }
       }
     }

--- a/apps/api/src/lexicon/lexicons.ts
+++ b/apps/api/src/lexicon/lexicons.ts
@@ -6008,6 +6008,76 @@ export const schemaDict = {
             description: "The author of the shout.",
             ref: "lex:app.rocksky.shout.defs#author",
           },
+          gif: {
+            type: "ref",
+            description: "An attached GIF, sticker, or clip.",
+            ref: "lex:app.rocksky.shout.defs#gif",
+          },
+          facets: {
+            type: "array",
+            description:
+              "Mentions of other actors within the message, anchored to UTF-8 byte ranges.",
+            items: {
+              type: "ref",
+              ref: "lex:app.rocksky.shout.defs#mention",
+            },
+          },
+        },
+      },
+      mention: {
+        type: "object",
+        description:
+          "A mention of another actor within the shout message, anchored to a UTF-8 byte range in the message.",
+        required: ["did", "byteStart", "byteEnd"],
+        properties: {
+          did: {
+            type: "string",
+            description: "The DID of the mentioned actor.",
+            format: "did",
+          },
+          byteStart: {
+            type: "integer",
+            description: "Inclusive UTF-8 byte offset of the mention start.",
+            minimum: 0,
+          },
+          byteEnd: {
+            type: "integer",
+            description: "Exclusive UTF-8 byte offset of the mention end.",
+            minimum: 0,
+          },
+        },
+      },
+      gif: {
+        type: "object",
+        description:
+          "A GIF, sticker, or clip embedded in a shout. `url` may point at an image (GIF/WebP) or a video (MP4); the client decides how to render it from the file extension.",
+        required: ["url"],
+        properties: {
+          url: {
+            type: "string",
+            description: "Direct URL of the animated GIF/MP4.",
+            format: "uri",
+          },
+          previewUrl: {
+            type: "string",
+            description: "Smaller still/preview image URL.",
+            format: "uri",
+          },
+          alt: {
+            type: "string",
+            description: "Alternative text describing the media.",
+            maxLength: 512,
+          },
+          width: {
+            type: "integer",
+            description: "The intrinsic width of the media in pixels.",
+            minimum: 0,
+          },
+          height: {
+            type: "integer",
+            description: "The intrinsic height of the media in pixels.",
+            minimum: 0,
+          },
         },
       },
     },
@@ -6343,12 +6413,12 @@ export const schemaDict = {
         key: "tid",
         record: {
           type: "object",
-          required: ["message", "createdAt", "subject"],
+          required: ["createdAt", "subject"],
           properties: {
             message: {
               type: "string",
-              description: "The message of the shout.",
-              minLength: 1,
+              description:
+                "The message of the shout. Optional when a gif/sticker/clip is attached.",
               maxLength: 1000,
             },
             createdAt: {
@@ -6363,6 +6433,21 @@ export const schemaDict = {
             subject: {
               type: "ref",
               ref: "lex:com.atproto.repo.strongRef",
+            },
+            gif: {
+              type: "ref",
+              description:
+                "An attached GIF, sticker, or clip (e.g. from KLIPY).",
+              ref: "lex:app.rocksky.shout.defs#gif",
+            },
+            facets: {
+              type: "array",
+              description:
+                "Mentions of other actors within the message, anchored to UTF-8 byte ranges.",
+              items: {
+                type: "ref",
+                ref: "lex:app.rocksky.shout.defs#mention",
+              },
             },
           },
         },

--- a/apps/api/src/lexicon/types/app/rocksky/shout.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/shout.ts
@@ -6,14 +6,19 @@ import { lexicons } from "../../../lexicons";
 import { isObj, hasProp } from "../../../util";
 import { CID } from "multiformats/cid";
 import type * as ComAtprotoRepoStrongRef from "../../com/atproto/repo/strongRef";
+import type * as AppRockskyShoutDefs from "./shout/defs";
 
 export interface Record {
-  /** The message of the shout. */
-  message: string;
+  /** The message of the shout. Optional when a gif/sticker/clip is attached. */
+  message?: string;
   /** The date when the shout was created. */
   createdAt: string;
   parent?: ComAtprotoRepoStrongRef.Main;
   subject: ComAtprotoRepoStrongRef.Main;
+  /** An attached GIF, sticker, or clip (e.g. from KLIPY). */
+  gif?: AppRockskyShoutDefs.Gif;
+  /** Mentions of other actors within the message, anchored to UTF-8 byte ranges. */
+  facets?: AppRockskyShoutDefs.Mention[];
   [k: string]: unknown;
 }
 

--- a/apps/api/src/lexicon/types/app/rocksky/shout/defs.ts
+++ b/apps/api/src/lexicon/types/app/rocksky/shout/defs.ts
@@ -42,6 +42,10 @@ export interface ShoutView {
   /** The date and time when the shout was created. */
   createdAt?: string;
   author?: Author;
+  /** An attached GIF, sticker, or clip. */
+  gif?: Gif;
+  /** Mentions of other actors within the message, anchored to UTF-8 byte ranges. */
+  facets?: Mention[];
   [k: string]: unknown;
 }
 
@@ -55,4 +59,50 @@ export function isShoutView(v: unknown): v is ShoutView {
 
 export function validateShoutView(v: unknown): ValidationResult {
   return lexicons.validate("app.rocksky.shout.defs#shoutView", v);
+}
+
+export interface Gif {
+  /** Direct URL of the animated GIF/MP4. */
+  url: string;
+  /** Smaller still/preview image URL. */
+  previewUrl?: string;
+  /** Alternative text describing the media. */
+  alt?: string;
+  /** The intrinsic width of the media in pixels. */
+  width?: number;
+  /** The intrinsic height of the media in pixels. */
+  height?: number;
+  [k: string]: unknown;
+}
+
+export function isGif(v: unknown): v is Gif {
+  return (
+    isObj(v) && hasProp(v, "$type") && v.$type === "app.rocksky.shout.defs#gif"
+  );
+}
+
+export function validateGif(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.shout.defs#gif", v);
+}
+
+export interface Mention {
+  /** The DID of the mentioned actor. */
+  did: string;
+  /** Inclusive UTF-8 byte offset of the mention start. */
+  byteStart: number;
+  /** Exclusive UTF-8 byte offset of the mention end. */
+  byteEnd: number;
+  [k: string]: unknown;
+}
+
+export function isMention(v: unknown): v is Mention {
+  return (
+    isObj(v) &&
+    hasProp(v, "$type") &&
+    v.$type === "app.rocksky.shout.defs#mention"
+  );
+}
+
+export function validateMention(v: unknown): ValidationResult {
+  return lexicons.validate("app.rocksky.shout.defs#mention", v);
 }

--- a/apps/api/src/schema/shouts.ts
+++ b/apps/api/src/schema/shouts.ts
@@ -1,5 +1,6 @@
 import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import type { Mention } from "../types/shout";
 import albums from "./albums";
 import scrobbles from "./scrobbles";
 import tracks from "./tracks";
@@ -17,6 +18,12 @@ const shouts = pgTable("shouts", {
     .references(() => users.id)
     .notNull(),
   parentId: text("parent_id").references(() => shouts.id),
+  gifUrl: text("gif_url"),
+  gifPreviewUrl: text("gif_preview_url"),
+  gifAlt: text("gif_alt"),
+  gifWidth: integer("gif_width"),
+  gifHeight: integer("gif_height"),
+  facets: jsonb("facets").$type<Mention[]>(),
   createdAt: timestamp("xata_createdat").defaultNow().notNull(),
   updatedAt: timestamp("xata_updatedat").defaultNow().notNull(),
 });

--- a/apps/api/src/shouts/shouts.service.ts
+++ b/apps/api/src/shouts/shouts.service.ts
@@ -107,7 +107,9 @@ export async function createShout(
   const record = {
     $type: "app.rocksky.shout",
     subject: subjectRef.value,
-    message: shout.message,
+    ...(shout.message ? { message: shout.message } : {}),
+    ...(shout.gif ? { gif: shout.gif } : {}),
+    ...(shout.facets?.length ? { facets: shout.facets } : {}),
     createdAt: new Date().toISOString(),
   };
 
@@ -131,13 +133,19 @@ export async function createShout(
     const createdShout = await ctx.db
       .insert(shouts)
       .values({
-        content: shout.message,
+        content: shout.message ?? "",
         uri,
         authorId: user.id,
         albumId: album?.id,
         artistId: artist?.id,
         trackId: track?.id,
         scrobbleId: scrobble?.scrobble.id,
+        gifUrl: shout.gif?.url,
+        gifPreviewUrl: shout.gif?.previewUrl,
+        gifAlt: shout.gif?.alt,
+        gifWidth: shout.gif?.width,
+        gifHeight: shout.gif?.height,
+        facets: shout.facets?.length ? shout.facets : null,
       })
       .returning()
       .then((rows) => rows[0]);
@@ -265,7 +273,9 @@ export async function replyShout(
     $type: "app.rocksky.shout",
     subject: subjectRef.value,
     parent: parentRef.value,
-    message: reply.message,
+    ...(reply.message ? { message: reply.message } : {}),
+    ...(reply.gif ? { gif: reply.gif } : {}),
+    ...(reply.facets?.length ? { facets: reply.facets } : {}),
     createdAt: new Date().toISOString(),
   };
 
@@ -289,7 +299,7 @@ export async function replyShout(
     const createdShout = await ctx.db
       .insert(shouts)
       .values({
-        content: reply.message,
+        content: reply.message ?? "",
         uri,
         parentId: shout.shout.id,
         authorId: user.id,
@@ -297,6 +307,12 @@ export async function replyShout(
         albumId: shout.album?.id,
         artistId: shout.artist?.id,
         scrobbleId: shout.scrobble?.id,
+        gifUrl: reply.gif?.url,
+        gifPreviewUrl: reply.gif?.previewUrl,
+        gifAlt: reply.gif?.alt,
+        gifWidth: reply.gif?.width,
+        gifHeight: reply.gif?.height,
+        facets: reply.facets?.length ? reply.facets : null,
       })
       .returning()
       .then((rows) => rows[0]);

--- a/apps/api/src/types/shout.ts
+++ b/apps/api/src/types/shout.ts
@@ -1,7 +1,31 @@
 import z from "zod";
 
-export const shoutSchema = z.object({
-  message: z.string().nonempty(),
+export const gifSchema = z.object({
+  url: z.string().url(),
+  previewUrl: z.string().url().optional(),
+  alt: z.string().max(512).optional(),
+  width: z.number().int().min(0).optional(),
+  height: z.number().int().min(0).optional(),
 });
+
+export type Gif = z.infer<typeof gifSchema>;
+
+export const mentionSchema = z.object({
+  did: z.string(),
+  byteStart: z.number().int().min(0),
+  byteEnd: z.number().int().min(0),
+});
+
+export type Mention = z.infer<typeof mentionSchema>;
+
+export const shoutSchema = z
+  .object({
+    message: z.string().max(1000).optional(),
+    gif: gifSchema.optional(),
+    facets: z.array(mentionSchema).optional(),
+  })
+  .refine((v) => (v.message?.trim().length ?? 0) > 0 || v.gif != null, {
+    message: "A shout must have a message or a gif.",
+  });
 
 export type Shout = z.infer<typeof shoutSchema>;

--- a/apps/api/src/users/app.ts
+++ b/apps/api/src/users/app.ts
@@ -32,6 +32,17 @@ import { dedupeTracksKeepLyrics } from "./utils";
 
 const app = new Hono();
 
+/** Shared media (gif/sticker/clip) + mention-facet columns selected alongside
+ * every shout row. */
+const shoutGifColumns = {
+  gifUrl: tables.shouts.gifUrl,
+  gifPreviewUrl: tables.shouts.gifPreviewUrl,
+  gifAlt: tables.shouts.gifAlt,
+  gifWidth: tables.shouts.gifWidth,
+  gifHeight: tables.shouts.gifHeight,
+  facets: tables.shouts.facets,
+};
+
 app.get("/:did/likes", async (c) => {
   requestCounter.add(1, { method: "GET", route: "/users/:did/likes" });
   const did = c.req.param("did");
@@ -1074,6 +1085,7 @@ app.get("/:did/app.rocksky.artist/:rkey/shouts", async (c) => {
         ? {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,
@@ -1089,6 +1101,7 @@ app.get("/:did/app.rocksky.artist/:rkey/shouts", async (c) => {
         : {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             parent: tables.shouts.parentId,
             uri: tables.shouts.uri,
@@ -1157,6 +1170,7 @@ app.get("/:did/app.rocksky.album/:rkey/shouts", async (c) => {
         ? {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             parent: tables.shouts.parentId,
             uri: tables.shouts.uri,
@@ -1172,6 +1186,7 @@ app.get("/:did/app.rocksky.album/:rkey/shouts", async (c) => {
         : {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             parent: tables.shouts.parentId,
             uri: tables.shouts.uri,
@@ -1240,6 +1255,7 @@ app.get("/:did/app.rocksky.song/:rkey/shouts", async (c) => {
         ? {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,
@@ -1255,6 +1271,7 @@ app.get("/:did/app.rocksky.song/:rkey/shouts", async (c) => {
         : {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,
@@ -1323,6 +1340,7 @@ app.get("/:did/app.rocksky.scrobble/:rkey/shouts", async (c) => {
         ? {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,
@@ -1338,6 +1356,7 @@ app.get("/:did/app.rocksky.scrobble/:rkey/shouts", async (c) => {
         : {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,
@@ -1409,6 +1428,7 @@ app.get("/:did/shouts", async (c) => {
         ? {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,
@@ -1431,6 +1451,7 @@ app.get("/:did/shouts", async (c) => {
         : {
             id: tables.shouts.id,
             content: tables.shouts.content,
+            ...shoutGifColumns,
             createdAt: tables.shouts.createdAt,
             uri: tables.shouts.uri,
             parent: tables.shouts.parentId,

--- a/apps/web-mobile/.env.example
+++ b/apps/web-mobile/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:8000
+VITE_KLIPY_API_KEY=
+

--- a/apps/web-mobile/src/api/klipy.ts
+++ b/apps/web-mobile/src/api/klipy.ts
@@ -1,0 +1,219 @@
+/**
+ * KLIPY media API (GIFs, stickers, clips). Set `VITE_KLIPY_API_KEY` to enable
+ * the picker. https://klipy.com/developers — endpoints follow
+ * `api.klipy.com/api/v1/{key}/{type}/{search|trending}`.
+ *
+ * Note: this API/plan exposes `gifs`, `stickers`, and `clips`. There is no
+ * `memes` route (it 404s "Route not found"), so we don't offer that tab.
+ */
+const KLIPY_KEY = import.meta.env.VITE_KLIPY_API_KEY ?? "";
+const KLIPY_BASE = "https://api.klipy.com/api/v1";
+
+/** True when a key is configured; the picker degrades to a hint otherwise. */
+export const KLIPY_ENABLED = Boolean(KLIPY_KEY);
+
+export type KlipyMediaType = "gifs" | "stickers" | "clips";
+
+export const KLIPY_TABS: { type: KlipyMediaType; label: string }[] = [
+  { type: "gifs", label: "GIFs" },
+  { type: "stickers", label: "Stickers" },
+  { type: "clips", label: "Clips" },
+];
+
+/** The media embed persisted on a shout record (mirrors app.rocksky.shout#gif). */
+export interface GifEmbed {
+  url: string;
+  previewUrl?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+/** A pickable media item: renders in the grid, embeds on select. */
+export interface MediaResult extends GifEmbed {
+  id: string;
+  /** True when `url` is a video (mp4) rather than an image. */
+  isVideo: boolean;
+}
+
+/** True when a URL points at a video the UI should render with <video>. */
+export function isVideoUrl(url: string): boolean {
+  return /\.mp4($|\?)/i.test(url);
+}
+
+interface Rendition {
+  url: string;
+  width?: number;
+  height?: number;
+}
+
+// KLIPY returns two different `file` shapes:
+//  • gifs / stickers — nested by size then format:
+//      file: { md: { gif: {url,width,height}, webp: {...}, mp4: {...} }, ... }
+//  • clips — flat format → url string, with dimensions in a sibling `file_meta`:
+//      file: { mp4: "url", gif: "url", webp: "url" }
+//      file_meta: { mp4: {width,height}, gif: {...}, webp: {...} }
+type NestedRendition = {
+  url?: string;
+  width?: number | string;
+  height?: number | string;
+};
+type NestedFormatMap = Record<string, NestedRendition | undefined>;
+type NestedFile = Record<string, NestedFormatMap | undefined>;
+type FlatFile = Record<string, string | undefined>;
+type MetaMap = Record<
+  string,
+  { width?: number | string; height?: number | string } | undefined
+>;
+
+interface KlipyItem {
+  id?: number | string;
+  slug?: string;
+  title?: string;
+  file?: NestedFile | FlatFile;
+  files?: NestedFile | FlatFile;
+  file_meta?: MetaMap;
+}
+
+const num = (v: number | string | undefined): number | undefined => {
+  const n = typeof v === "string" ? Number(v) : v;
+  return Number.isFinite(n) ? (n as number) : undefined;
+};
+
+/** A `file` whose top-level values are strings is the flat (clips) shape. */
+function isFlatFile(file: NestedFile | FlatFile): file is FlatFile {
+  return Object.values(file).some((v) => typeof v === "string");
+}
+
+/** Flat (clips) shape → renditions from format→url strings + `file_meta` dims. */
+function pickFlat(
+  file: FlatFile,
+  meta: MetaMap | undefined,
+  wantVideo: boolean,
+): { full?: Rendition; preview?: Rendition } {
+  const at = (fmt: string): Rendition | undefined => {
+    const url = file[fmt];
+    if (typeof url !== "string" || !url) return undefined;
+    const m = meta?.[fmt];
+    return { url, width: num(m?.width), height: num(m?.height) };
+  };
+  const fullFmts = wantVideo ? ["mp4", "webp", "gif"] : ["gif", "webp", "mp4"];
+  let full: Rendition | undefined;
+  for (const f of fullFmts) if (!full) full = at(f);
+  let preview: Rendition | undefined;
+  for (const f of ["gif", "webp", "jpg", "png"]) if (!preview) preview = at(f);
+  return { full, preview };
+}
+
+/** Nested (gifs/stickers) shape → walk size then format. */
+function pickNested(
+  file: NestedFile,
+  wantVideo: boolean,
+): { full?: Rendition; preview?: Rendition } {
+  const sizes = ["md", "sm", "hd", "lg", "xs"];
+  const fullFmts = wantVideo ? ["mp4", "webp", "gif"] : ["gif", "webp", "mp4"];
+  const previewFmts = ["webp", "gif", "png", "jpg"];
+  const norm = (r: NestedRendition | undefined): Rendition | undefined =>
+    r?.url ? { url: r.url, width: num(r.width), height: num(r.height) } : undefined;
+
+  let full: Rendition | undefined;
+  for (const s of sizes) {
+    const fm = file[s];
+    if (!fm) continue;
+    for (const f of fullFmts) if (!full) full = norm(fm[f]);
+    if (full) break;
+  }
+  let preview: Rendition | undefined;
+  for (const s of ["sm", "md", "hd", "xs"]) {
+    const fm = file[s];
+    if (!fm) continue;
+    for (const f of previewFmts) if (!preview) preview = norm(fm[f]);
+    if (preview) break;
+  }
+  return { full, preview };
+}
+
+function toResult(item: KlipyItem, type: KlipyMediaType): MediaResult | null {
+  const wantVideo = type === "clips";
+  const file = item.file ?? item.files;
+  if (!file) return null;
+  const { full, preview } = isFlatFile(file)
+    ? pickFlat(file, item.file_meta, wantVideo)
+    : pickNested(file, wantVideo);
+  if (!full?.url) return null;
+  return {
+    id: String(item.id ?? item.slug ?? full.url),
+    url: full.url,
+    previewUrl: preview?.url ?? full.url,
+    alt: item.title?.trim() || item.slug || undefined,
+    width: full.width,
+    height: full.height,
+    isVideo: isVideoUrl(full.url),
+  };
+}
+
+/** A stable per-browser id KLIPY uses to personalize trending/recents. */
+function customerId(): string {
+  try {
+    const key = "rocksky:klipy-cid";
+    let v = localStorage.getItem(key);
+    if (!v) {
+      v = Math.random().toString(36).slice(2) + Date.now().toString(36);
+      localStorage.setItem(key, v);
+    }
+    return v;
+  } catch {
+    return "anon";
+  }
+}
+
+async function request(
+  type: KlipyMediaType,
+  action: "search" | "trending",
+  params: URLSearchParams,
+): Promise<MediaResult[]> {
+  if (!KLIPY_KEY) return [];
+  params.set("customer_id", customerId());
+  const url = `${KLIPY_BASE}/${encodeURIComponent(KLIPY_KEY)}/${type}/${action}?${params}`;
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      data?: { data?: KlipyItem[] } | KlipyItem[];
+    };
+    const list = Array.isArray(json.data)
+      ? json.data
+      : (json.data?.data ?? []);
+    return list
+      .map((it) => toResult(it, type))
+      .filter((r): r is MediaResult => r !== null);
+  } catch {
+    return [];
+  }
+}
+
+/** Search KLIPY media of a given type; empty query → trending. */
+export function searchMedia(
+  type: KlipyMediaType,
+  q: string,
+  perPage = 24,
+): Promise<MediaResult[]> {
+  const query = q.trim();
+  if (!query) {
+    return request(
+      type,
+      "trending",
+      new URLSearchParams({ page: "1", per_page: String(perPage) }),
+    );
+  }
+  return request(
+    type,
+    "search",
+    new URLSearchParams({ q: query, page: "1", per_page: String(perPage) }),
+  );
+}
+
+/** Adapt a stored gif embed back into the picker's MediaResult shape. */
+export function gifEmbedToMedia(g: GifEmbed): MediaResult {
+  return { ...g, id: g.url, isVideo: isVideoUrl(g.url) };
+}

--- a/apps/web-mobile/src/components/Shout/MediaPicker/MediaPicker.tsx
+++ b/apps/web-mobile/src/components/Shout/MediaPicker/MediaPicker.tsx
@@ -1,0 +1,247 @@
+import styled from "@emotion/styled";
+import { IconSearch, IconX } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  KLIPY_ENABLED,
+  KLIPY_TABS,
+  searchMedia,
+  type KlipyMediaType,
+  type MediaResult,
+} from "../../../api/klipy";
+
+const Panel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 340px;
+  max-width: calc(100vw - 32px);
+  padding: 12px;
+  border-radius: 12px;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-input-background);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+`;
+
+const TopBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Tabs = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+const Tab = styled.button<{ active: boolean }>`
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: all 0.15s ease;
+  background-color: ${({ active }) =>
+    active ? "var(--color-purple)" : "transparent"};
+  color: ${({ active }) =>
+    active ? "var(--color-button-text)" : "var(--color-text-muted)"};
+
+  &:hover {
+    color: var(--color-text);
+  }
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  width: 28px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background-color: transparent;
+  color: var(--color-text-muted);
+
+  &:hover {
+    background-color: var(--color-input-background);
+    color: var(--color-text);
+  }
+`;
+
+const SearchBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-radius: 8px;
+  background-color: var(--color-input-background);
+`;
+
+const SearchInput = styled.input`
+  height: 34px;
+  width: 100%;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  font-size: 14px;
+  color: var(--color-text);
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  height: 300px;
+  align-content: start;
+  overflow-y: auto;
+`;
+
+const Tile = styled.button`
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--color-input-background);
+  cursor: pointer;
+  padding: 0;
+  background-color: var(--color-input-background);
+  transition: transform 0.12s ease;
+
+  &:hover {
+    transform: scale(1.03);
+    border-color: var(--color-purple);
+  }
+
+  & > img,
+  & > video {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
+
+const Empty = styled.div`
+  grid-column: span 3;
+  padding: 32px 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-text-muted);
+`;
+
+const Credit = styled.p`
+  margin: 0;
+  text-align: center;
+  font-size: 10px;
+  color: var(--color-text-muted);
+`;
+
+/** Debounce a fast-changing value. */
+function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+interface MediaPickerProps {
+  onSelect: (media: MediaResult) => void;
+  onClose: () => void;
+}
+
+/** KLIPY-powered GIF / sticker / clip picker. */
+function MediaPicker({ onSelect, onClose }: MediaPickerProps) {
+  const [type, setType] = useState<KlipyMediaType>("gifs");
+  const [query, setQuery] = useState("");
+  const debounced = useDebounced(query, 350);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  const { data, isFetching } = useQuery({
+    queryKey: ["klipy", type, debounced],
+    queryFn: () => searchMedia(type, debounced),
+    enabled: KLIPY_ENABLED,
+    staleTime: 60_000,
+  });
+
+  const results = data ?? [];
+
+  return (
+    <Panel onClick={(e) => e.stopPropagation()}>
+      <TopBar>
+        <Tabs>
+          {KLIPY_TABS.map((tab) => (
+            <Tab
+              key={tab.type}
+              type="button"
+              active={type === tab.type}
+              onClick={() => setType(tab.type)}
+            >
+              {tab.label}
+            </Tab>
+          ))}
+        </Tabs>
+        <CloseButton type="button" aria-label="Close" onClick={onClose}>
+          <IconX size={16} />
+        </CloseButton>
+      </TopBar>
+
+      <SearchBox>
+        <IconSearch size={14} color="var(--color-text-muted)" />
+        <SearchInput
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`Search ${type}`}
+        />
+      </SearchBox>
+
+      <Grid>
+        {!KLIPY_ENABLED ? (
+          <Empty>
+            Set <code>VITE_KLIPY_API_KEY</code> to enable GIFs, stickers &amp;
+            clips.
+          </Empty>
+        ) : results.length === 0 ? (
+          <Empty>{isFetching ? "Loading…" : "No results"}</Empty>
+        ) : (
+          results.map((m) => (
+            <Tile
+              key={m.id}
+              type="button"
+              title={m.alt}
+              onClick={() => onSelect(m)}
+            >
+              {m.isVideo ? (
+                <video
+                  src={m.url}
+                  poster={m.previewUrl}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                />
+              ) : (
+                <img src={m.previewUrl ?? m.url} alt={m.alt ?? ""} loading="lazy" />
+              )}
+            </Tile>
+          ))
+        )}
+      </Grid>
+
+      <Credit>Powered by KLIPY</Credit>
+    </Panel>
+  );
+}
+
+export default MediaPicker;

--- a/apps/web-mobile/src/components/Shout/MediaPicker/index.tsx
+++ b/apps/web-mobile/src/components/Shout/MediaPicker/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./MediaPicker";

--- a/apps/web-mobile/src/components/Shout/MentionTextarea/MentionTextarea.tsx
+++ b/apps/web-mobile/src/components/Shout/MentionTextarea/MentionTextarea.tsx
@@ -1,0 +1,228 @@
+import styled from "@emotion/styled";
+import { useQuery } from "@tanstack/react-query";
+import { Textarea, type TextareaProps } from "baseui/textarea";
+import { useEffect, useRef, useState } from "react";
+import { getCaretCoordinates } from "../../../lib/caret";
+import {
+  activeMentionToken,
+  searchActorsTypeahead,
+} from "../../../lib/richtext";
+
+/**
+ * A baseui Textarea with an `@mention` typeahead popup. Fully controlled via
+ * `value`/`onChange`; the popup queries the Bluesky AppView and inserts the
+ * chosen handle. Purely a UI affordance — facets are resolved separately on
+ * submit via `resolveMentionFacets`.
+ */
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const Popup = styled.ul`
+  position: absolute;
+  z-index: 30;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 224px;
+  width: 256px;
+  max-width: calc(100% - 8px);
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid var(--color-input-background);
+  background-color: var(--color-background);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+`;
+
+const Item = styled.button<{ active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  background-color: ${({ active }) =>
+    active ? "var(--color-input-background)" : "transparent"};
+
+  &:hover {
+    background-color: var(--color-input-background);
+  }
+`;
+
+const Avatar = styled.span`
+  display: flex;
+  height: 28px;
+  width: 28px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: 999px;
+  background-color: var(--color-input-background);
+
+  & > img {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+  }
+`;
+
+const Names = styled.span`
+  min-width: 0;
+`;
+
+const DisplayName = styled.span`
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text);
+  font-size: 14px;
+`;
+
+const Handle = styled.span`
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  font-size: 12px;
+`;
+
+/** Debounce a fast-changing value. */
+function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+interface MentionTextareaProps extends Omit<TextareaProps, "onChange"> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function MentionTextarea({ value, onChange, ...rest }: MentionTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [mention, setMention] = useState<{ start: number; query: string } | null>(
+    null,
+  );
+  const [caret, setCaret] = useState<{ top: number; left: number } | null>(null);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const debouncedQuery = useDebounced(mention?.query ?? "", 200);
+
+  const { data: suggestions = [] } = useQuery({
+    queryKey: ["mention-typeahead", debouncedQuery],
+    queryFn: () => searchActorsTypeahead(debouncedQuery),
+    enabled: mention !== null && debouncedQuery.length >= 1,
+    staleTime: 30_000,
+  });
+  const popupOpen = mention !== null && suggestions.length > 0;
+
+  const syncMention = (text: string, caretPos: number) => {
+    const token = activeMentionToken(text, caretPos);
+    setMention(token);
+    setActiveIdx(0);
+    const el = textareaRef.current;
+    if (token && el) {
+      const c = getCaretCoordinates(el, token.start);
+      const maxLeft = Math.max(0, el.clientWidth - 256);
+      setCaret({
+        top: el.offsetTop + c.top + c.height,
+        left: el.offsetLeft + Math.min(c.left, maxLeft),
+      });
+    } else {
+      setCaret(null);
+    }
+  };
+
+  const insertMention = (handle: string) => {
+    if (!mention) return;
+    const el = textareaRef.current;
+    const caretPos = el?.selectionStart ?? value.length;
+    const next =
+      value.slice(0, mention.start) + `@${handle} ` + value.slice(caretPos);
+    onChange(next);
+    setMention(null);
+    setCaret(null);
+    requestAnimationFrame(() => {
+      const pos = mention.start + handle.length + 2;
+      el?.focus();
+      el?.setSelectionRange(pos, pos);
+    });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!popupOpen) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => (i + 1) % suggestions.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => (i - 1 + suggestions.length) % suggestions.length);
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      insertMention(suggestions[activeIdx]!.handle);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setMention(null);
+      setCaret(null);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Textarea
+        inputRef={textareaRef}
+        value={value}
+        onChange={(e) => {
+          onChange(e.currentTarget.value);
+          syncMention(e.currentTarget.value, e.currentTarget.selectionStart ?? 0);
+        }}
+        onClick={(e) =>
+          syncMention(
+            e.currentTarget.value,
+            e.currentTarget.selectionStart ?? 0,
+          )
+        }
+        onKeyUp={(e) =>
+          syncMention(
+            e.currentTarget.value,
+            e.currentTarget.selectionStart ?? 0,
+          )
+        }
+        onKeyDown={onKeyDown}
+        {...rest}
+      />
+
+      {popupOpen && caret && (
+        <Popup style={{ top: caret.top, left: caret.left }}>
+          {suggestions.map((s, i) => (
+            <li key={s.did}>
+              <Item
+                type="button"
+                active={i === activeIdx}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  insertMention(s.handle);
+                }}
+              >
+                <Avatar>{s.avatar && <img src={s.avatar} alt="" />}</Avatar>
+                <Names>
+                  <DisplayName>{s.displayName || s.handle}</DisplayName>
+                  <Handle>@{s.handle}</Handle>
+                </Names>
+              </Item>
+            </li>
+          ))}
+        </Popup>
+      )}
+    </Wrapper>
+  );
+}
+
+export default MentionTextarea;

--- a/apps/web-mobile/src/components/Shout/MentionTextarea/index.tsx
+++ b/apps/web-mobile/src/components/Shout/MentionTextarea/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./MentionTextarea";

--- a/apps/web-mobile/src/components/Shout/RichText.tsx
+++ b/apps/web-mobile/src/components/Shout/RichText.tsx
@@ -1,0 +1,64 @@
+import styled from "@emotion/styled";
+import { Link } from "react-router";
+import { Fragment } from "react";
+import { type Mention, segmentText } from "../../lib/richtext";
+
+/**
+ * Renders a shout message as rich text: bare URLs become external links and
+ * `@mentions` become links to the mentioned user's profile. When the shout
+ * carries mention facets the links resolve to the exact DID; otherwise
+ * `@handles` are detected heuristically. Messages are still stored as plain
+ * strings + facets — this is purely presentational.
+ */
+
+const Anchor = styled.a`
+  color: var(--color-primary);
+  text-decoration: none;
+  word-break: break-word;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const MentionLink = styled(Link)`
+  color: var(--color-primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+interface RichTextProps {
+  children: string;
+  facets?: Mention[];
+}
+
+function RichText({ children, facets }: RichTextProps) {
+  const segments = segmentText(children, facets);
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.type === "mention" ? (
+          <MentionLink key={i} to={`/profile/${seg.target}`}>
+            {seg.value}
+          </MentionLink>
+        ) : seg.type === "link" ? (
+          <Anchor
+            key={i}
+            href={seg.href}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {seg.value}
+          </Anchor>
+        ) : (
+          <Fragment key={i}>{seg.value}</Fragment>
+        ),
+      )}
+    </>
+  );
+}
+
+export default RichText;

--- a/apps/web-mobile/src/components/Shout/Shout.tsx
+++ b/apps/web-mobile/src/components/Shout/Shout.tsx
@@ -1,23 +1,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "baseui/button";
+import { PLACEMENT, StatefulPopover } from "baseui/popover";
 import { Spinner } from "baseui/spinner";
-import { Textarea } from "baseui/textarea";
 import { LabelLarge, LabelMedium } from "baseui/typography";
+import { IconGif, IconX } from "@tabler/icons-react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useLocation, useParams } from "react-router";
 import z from "zod";
+import { isVideoUrl, type MediaResult } from "../../api/klipy";
+import { resolveMentionFacets } from "../../lib/richtext";
 import { profileAtom } from "../../atoms/profile";
 import { shoutsAtom } from "../../atoms/shouts";
 import { userAtom } from "../../atoms/user";
 import useShout from "../../hooks/useShout";
+import MediaPicker from "./MediaPicker";
+import MentionTextarea from "./MentionTextarea";
 import SignInModal from "../SignInModal";
 import ShoutList from "./ShoutList";
 
 const ShoutSchema = z.object({
-  message: z.string().min(1).max(1000),
+  message: z.string().max(1000),
 });
 
 interface ShoutProps {
@@ -47,8 +52,12 @@ function Shout(props: ShoutProps) {
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
   const location = useLocation();
   const [loading, setLoading] = useState(false);
+  const [gif, setGif] = useState<MediaResult | null>(null);
 
   const onShout = async ({ message }: z.infer<typeof ShoutSchema>) => {
+    if (message.trim().length === 0 && !gif) {
+      return;
+    }
     setLoading(true);
     let uri = "";
 
@@ -72,7 +81,19 @@ function Shout(props: ShoutProps) {
       uri = `at://${did}/app.rocksky.scrobble/${rkey}`;
     }
 
-    await shout(uri, message);
+    const gifEmbed = gif
+      ? {
+          url: gif.url,
+          previewUrl: gif.previewUrl,
+          alt: gif.alt,
+          width: gif.width,
+          height: gif.height,
+        }
+      : undefined;
+
+    const facets = message.trim() ? await resolveMentionFacets(message) : [];
+
+    await shout(uri, message, gifEmbed, facets.length ? facets : undefined);
 
     const data = await getShouts(uri);
     setShouts({
@@ -81,7 +102,7 @@ function Shout(props: ShoutProps) {
     });
 
     setLoading(false);
-
+    setGif(null);
     reset();
   };
 
@@ -97,6 +118,16 @@ function Shout(props: ShoutProps) {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,
@@ -119,8 +150,9 @@ function Shout(props: ShoutProps) {
             name="message"
             control={control}
             render={({ field }) => (
-              <Textarea
-                {...field}
+              <MentionTextarea
+                value={field.value}
+                onChange={field.onChange}
                 placeholder={
                   props.type === "profile"
                     ? `@${profile?.handle}, leave a shout for @${user?.handle} ...`
@@ -139,17 +171,70 @@ function Shout(props: ShoutProps) {
             )}
           />
 
+          {gif && (
+            <div className="mt-[10px] relative w-fit max-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-input-background)]">
+              {isVideoUrl(gif.url) ? (
+                <video
+                  src={gif.url}
+                  className="block w-full h-auto"
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                />
+              ) : (
+                <img
+                  src={gif.previewUrl ?? gif.url}
+                  alt={gif.alt ?? ""}
+                  className="block w-full h-auto"
+                />
+              )}
+              <button
+                type="button"
+                aria-label="Remove media"
+                onClick={() => setGif(null)}
+                className="absolute right-[6px] top-[6px] flex h-[24px] w-[24px] items-center justify-center rounded-full bg-black/60 text-white cursor-pointer border-none hover:bg-black/80"
+              >
+                <IconX size={14} />
+              </button>
+            </div>
+          )}
+
           <div
             style={{
               marginTop: 15,
               display: "flex",
-              justifyContent: "flex-end",
+              justifyContent: "space-between",
+              alignItems: "center",
             }}
           >
+            <StatefulPopover
+              placement={PLACEMENT.bottomLeft}
+              overrides={{ Body: { style: { zIndex: 3 } } }}
+              content={({ close }) => (
+                <MediaPicker
+                  onSelect={(m) => {
+                    setGif(m);
+                    close();
+                  }}
+                  onClose={close}
+                />
+              )}
+            >
+              <button
+                type="button"
+                aria-label="Add a GIF, sticker or clip"
+                className="flex items-center gap-[4px] rounded-full px-[10px] py-[5px] text-[13px] cursor-pointer border-none bg-transparent text-[var(--color-text-muted)] hover:bg-[var(--color-input-background)] hover:text-[var(--color-text)]"
+              >
+                <IconGif size={20} />
+                GIF
+              </button>
+            </StatefulPopover>
+
             {!loading && (
               <Button
                 disabled={
-                  watch("message").length === 0 ||
+                  (watch("message").length === 0 && !gif) ||
                   watch("message").length > 1000
                 }
                 onClick={handleSubmit(onShout)}

--- a/apps/web-mobile/src/components/Shout/ShoutList/Shout/ReplyModal/ReplyModal.tsx
+++ b/apps/web-mobile/src/components/Shout/ShoutList/Shout/ReplyModal/ReplyModal.tsx
@@ -1,10 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { PLACEMENT, StatefulPopover } from "baseui/popover";
+import { IconGif, IconX } from "@tabler/icons-react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Link, useParams } from "react-router";
+import { isVideoUrl, type MediaResult } from "../../../../../api/klipy";
+import { type Mention, resolveMentionFacets } from "../../../../../lib/richtext";
 import { profileAtom } from "../../../../../atoms/profile";
 import { shoutsAtom } from "../../../../../atoms/shouts";
 import useShout from "../../../../../hooks/useShout";
+import MediaPicker from "../../../MediaPicker";
+import MentionTextarea from "../../../MentionTextarea";
+import RichText from "../../../RichText";
 
 interface ReplyModalProps {
   isOpen: boolean;
@@ -12,6 +19,7 @@ interface ReplyModalProps {
   shout: {
     uri: string;
     message: string;
+    facets?: Mention[];
     user: {
       avatar: string;
       displayName: string;
@@ -28,7 +36,7 @@ function ReplyModal({ isOpen, close, shout }: ReplyModalProps) {
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [gif, setGif] = useState<MediaResult | null>(null);
 
   if (!isOpen) return null;
 
@@ -44,6 +52,16 @@ function ReplyModal({ isOpen, close, shout }: ReplyModalProps) {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,
@@ -56,9 +74,19 @@ function ReplyModal({ isOpen, close, shout }: ReplyModalProps) {
   };
 
   const onReply = async () => {
-    if (!message.trim() || loading) return;
+    if ((!message.trim() && !gif) || loading) return;
     setLoading(true);
-    await reply(shout.uri, message);
+    const gifEmbed = gif
+      ? {
+          url: gif.url,
+          previewUrl: gif.previewUrl,
+          alt: gif.alt,
+          width: gif.width,
+          height: gif.height,
+        }
+      : undefined;
+    const facets = message.trim() ? await resolveMentionFacets(message) : [];
+    await reply(shout.uri, message, gifEmbed, facets.length ? facets : undefined);
 
     let uri = "";
     if (location.pathname.startsWith("/profile")) uri = `at://${did}`;
@@ -74,10 +102,11 @@ function ReplyModal({ isOpen, close, shout }: ReplyModalProps) {
 
     setLoading(false);
     setMessage("");
+    setGif(null);
     close();
   };
 
-  const canReply = message.trim() && !loading;
+  const canReply = (message.trim() || gif) && !loading;
 
   return (
     <div className="fixed inset-0 z-50 flex items-end" onClick={close}>
@@ -115,7 +144,7 @@ function ReplyModal({ isOpen, close, shout }: ReplyModalProps) {
               {shout.user.displayName}
             </p>
             <p className="m-0 text-[13px] leading-snug text-[var(--color-text-muted)]">
-              {shout.message}
+              <RichText facets={shout.facets}>{shout.message}</RichText>
             </p>
           </div>
         </div>
@@ -125,18 +154,95 @@ function ReplyModal({ isOpen, close, shout }: ReplyModalProps) {
           {profile?.avatar && (
             <img src={profile.avatar} className="h-9 w-9 shrink-0 rounded-full" />
           )}
-          <textarea
-            ref={textareaRef}
-            autoFocus
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            placeholder="Write your reply..."
-            maxLength={1000}
-            className="min-h-[80px] flex-1 resize-none border-none bg-transparent font-[inherit] text-sm leading-relaxed outline-none text-[var(--color-text)]"
-          />
+          <div className="flex-1">
+            <MentionTextarea
+              value={message}
+              onChange={setMessage}
+              autoFocus
+              placeholder="Write your reply..."
+              maxLength={1000}
+              resize="vertical"
+              overrides={{
+                Root: {
+                  style: {
+                    border: "none",
+                    width: "100%",
+                  },
+                },
+                InputContainer: {
+                  style: {
+                    border: "none",
+                    backgroundColor: "transparent",
+                  },
+                },
+                Input: {
+                  style: {
+                    border: "none",
+                    backgroundColor: "transparent",
+                    color: "var(--color-text)",
+                    caretColor: "var(--color-primary)",
+                    fontFamily: "inherit",
+                  },
+                },
+              }}
+            />
+          </div>
         </div>
-        <div className="mt-1 text-right text-[11px] text-[var(--color-text-muted)]">
-          {message.length}/1000
+        {gif && (
+          <div className="ml-[46px] mt-[10px] relative w-fit max-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-input-background)]">
+            {isVideoUrl(gif.url) ? (
+              <video
+                src={gif.url}
+                className="block h-auto w-full"
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            ) : (
+              <img
+                src={gif.previewUrl ?? gif.url}
+                alt={gif.alt ?? ""}
+                className="block h-auto w-full"
+              />
+            )}
+            <button
+              type="button"
+              aria-label="Remove media"
+              onClick={() => setGif(null)}
+              className="absolute right-[6px] top-[6px] flex h-[24px] w-[24px] items-center justify-center rounded-full border-none bg-black/60 text-white cursor-pointer hover:bg-black/80"
+            >
+              <IconX size={14} />
+            </button>
+          </div>
+        )}
+
+        <div className="mt-2 flex items-center justify-between">
+          <StatefulPopover
+            placement={PLACEMENT.topLeft}
+            overrides={{ Body: { style: { zIndex: 60 } } }}
+            content={({ close: closePopover }) => (
+              <MediaPicker
+                onSelect={(m) => {
+                  setGif(m);
+                  closePopover();
+                }}
+                onClose={closePopover}
+              />
+            )}
+          >
+            <button
+              type="button"
+              aria-label="Add a GIF, sticker or clip"
+              className="flex items-center gap-[4px] rounded-full border-none bg-transparent px-[10px] py-[5px] text-[13px] text-[var(--color-text-muted)] cursor-pointer hover:bg-[var(--color-input-background)] hover:text-[var(--color-text)]"
+            >
+              <IconGif size={20} />
+              GIF
+            </button>
+          </StatefulPopover>
+          <span className="text-[11px] text-[var(--color-text-muted)]">
+            {message.length}/1000
+          </span>
         </div>
       </div>
     </div>

--- a/apps/web-mobile/src/components/Shout/ShoutList/Shout/Shout.tsx
+++ b/apps/web-mobile/src/components/Shout/ShoutList/Shout/Shout.tsx
@@ -3,12 +3,15 @@ import dayjs from "dayjs";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 import { Link } from "react-router";
+import { type GifEmbed, isVideoUrl } from "../../../../api/klipy";
 import { profileAtom } from "../../../../atoms/profile";
 import Heart from "../../../Icons/Heart";
 import HeartOutline from "../../../Icons/HeartOutline";
 import SignInModal from "../../../SignInModal";
 import useLike from "../../../../hooks/useLike";
 import useShout from "../../../../hooks/useShout";
+import { type Mention } from "../../../../lib/richtext";
+import RichText from "../../RichText";
 import DeleteShoutModal from "./DeleteShoutModal";
 import ReplyModal from "./ReplyModal";
 
@@ -20,6 +23,8 @@ interface ShoutProps {
     liked: boolean;
     reported: boolean;
     likes: number;
+    gif?: GifEmbed;
+    facets?: Mention[];
     user: {
       did: string;
       avatar: string;
@@ -121,9 +126,34 @@ function Shout({ shout, refetch }: ShoutProps) {
         </div>
 
         {/* Message */}
-        <p className="mb-2.5 mt-0 text-sm leading-[1.55] text-[var(--color-text)]">
-          {shout.message}
-        </p>
+        {shout.message && (
+          <p className="mb-2.5 mt-0 text-sm leading-[1.55] text-[var(--color-text)]">
+            <RichText facets={shout.facets}>{shout.message}</RichText>
+          </p>
+        )}
+
+        {/* Media */}
+        {shout.gif && (
+          <div className="mb-2.5 w-fit max-w-[260px] overflow-hidden rounded-[12px] border border-[var(--color-input-background)]">
+            {isVideoUrl(shout.gif.url) ? (
+              <video
+                src={shout.gif.url}
+                poster={shout.gif.previewUrl}
+                className="block h-auto w-full"
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            ) : (
+              <img
+                src={shout.gif.previewUrl ?? shout.gif.url}
+                alt={shout.gif.alt ?? ""}
+                className="block h-auto w-full"
+              />
+            )}
+          </div>
+        )}
 
         {/* Actions */}
         <div className="flex items-center gap-4">

--- a/apps/web-mobile/src/components/Shout/ShoutList/ShoutList.tsx
+++ b/apps/web-mobile/src/components/Shout/ShoutList/ShoutList.tsx
@@ -78,6 +78,16 @@ function ShoutList({ uri: uriProp }: { uri?: string } = {}) {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,

--- a/apps/web-mobile/src/hooks/useShout.tsx
+++ b/apps/web-mobile/src/hooks/useShout.tsx
@@ -1,12 +1,19 @@
 import axios from "axios";
 import { useCallback } from "react";
+import type { GifEmbed } from "../api/klipy";
+import type { Mention } from "../lib/richtext";
 import { API_URL } from "../consts";
 
 function useShout() {
-  const shout = async (uri: string, message: string) => {
+  const shout = async (
+    uri: string,
+    message: string,
+    gif?: GifEmbed,
+    facets?: Mention[]
+  ) => {
     const response = await axios.post(
       `${API_URL}/users/${uri.replace("at://", "")}/shouts`,
-      { message },
+      { message, gif, facets },
       {
         headers: {
           "Content-Type": "application/json",
@@ -29,10 +36,15 @@ function useShout() {
     return response.data;
   }, []);
 
-  const reply = async (uri: string, message: string) => {
+  const reply = async (
+    uri: string,
+    message: string,
+    gif?: GifEmbed,
+    facets?: Mention[]
+  ) => {
     const response = await axios.post(
       `${API_URL}/users/${uri.replace("at://", "")}/replies`,
-      { message },
+      { message, gif, facets },
       {
         headers: {
           "Content-Type": "application/json",

--- a/apps/web-mobile/src/lib/caret.ts
+++ b/apps/web-mobile/src/lib/caret.ts
@@ -1,0 +1,75 @@
+/**
+ * Pixel coordinates of the caret within a textarea, relative to the element's
+ * own top-left (padding box). Used to anchor the @-mention popup right under the
+ * text being typed instead of at the bottom of the whole field.
+ *
+ * Works by rendering an invisible "mirror" div that copies the textarea's text
+ * and relevant styles, then measuring a marker placed at the caret offset.
+ */
+const MIRRORED_PROPS = [
+  "boxSizing",
+  "width",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "letterSpacing",
+  "textTransform",
+  "wordSpacing",
+  "lineHeight",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "borderTopWidth",
+  "borderRightWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+  "whiteSpace",
+  "wordWrap",
+  "tabSize",
+] as const;
+
+export interface CaretCoords {
+  /** Offset from the textarea's top edge to the top of the caret line. */
+  top: number;
+  /** Offset from the textarea's left edge to the caret. */
+  left: number;
+  /** Line height at the caret. */
+  height: number;
+}
+
+export function getCaretCoordinates(
+  el: HTMLTextAreaElement,
+  position: number,
+): CaretCoords {
+  const style = window.getComputedStyle(el);
+  const mirror = document.createElement("div");
+
+  mirror.style.position = "absolute";
+  mirror.style.visibility = "hidden";
+  mirror.style.whiteSpace = "pre-wrap";
+  mirror.style.wordWrap = "break-word";
+  mirror.style.top = "0";
+  mirror.style.left = "-9999px";
+  for (const prop of MIRRORED_PROPS) {
+    mirror.style[prop as never] = style[prop as never];
+  }
+  // Overflow must not add scrollbars that shift metrics.
+  mirror.style.overflow = "hidden";
+
+  mirror.textContent = el.value.slice(0, position);
+  // A marker span at the caret; its offset is the caret position.
+  const marker = document.createElement("span");
+  marker.textContent = el.value.slice(position) || ".";
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const top = marker.offsetTop - el.scrollTop;
+  const left = marker.offsetLeft - el.scrollLeft;
+  const height =
+    parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.2;
+  document.body.removeChild(mirror);
+
+  return { top, left, height };
+}

--- a/apps/web-mobile/src/lib/richtext.ts
+++ b/apps/web-mobile/src/lib/richtext.ts
@@ -1,0 +1,246 @@
+/**
+ * Rich text helpers for shouts: detecting `@mentions`, resolving them to
+ * ATProto mention facets (UTF-8 byte ranges → DID), splitting a message into
+ * renderable segments, and typeahead actor search for the composer.
+ *
+ * Rocksky handles are ATProto/Bluesky handles, so resolution and typeahead go
+ * through the public Bluesky AppView (same as atradio.fm).
+ */
+
+const BSKY_APPVIEW = "https://public.api.bsky.app";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** UTF-8 byte length of a string (facets index by bytes, not code units). */
+function byteLength(s: string): number {
+  return encoder.encode(s).length;
+}
+
+/** A mention facet stored on a shout record. */
+export interface Mention {
+  did: string;
+  byteStart: number;
+  byteEnd: number;
+}
+
+/**
+ * Handle mentions like `@alice.bsky.social`. Matches the leading `@` plus a
+ * dotted handle; the capture excludes any trailing punctuation.
+ */
+const MENTION_RE =
+  /(^|[\s(])@([a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]|[a-zA-Z0-9])/g;
+
+export interface MentionSpan {
+  /** String (code-unit) index of the `@`. */
+  start: number;
+  /** String index just past the handle. */
+  end: number;
+  /** Handle without the leading `@`. */
+  handle: string;
+}
+
+/** Find `@handle` spans in text (string indices). */
+export function detectMentionSpans(text: string): MentionSpan[] {
+  const spans: MentionSpan[] = [];
+  for (const m of text.matchAll(MENTION_RE)) {
+    const lead = m[1] ?? "";
+    const handle = m[2];
+    if (!handle) continue;
+    const at = (m.index ?? 0) + lead.length;
+    spans.push({ start: at, end: at + 1 + handle.length, handle });
+  }
+  return spans;
+}
+
+/** Resolve a single handle to a DID via the public AppView (null on failure). */
+async function resolveHandle(handle: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${BSKY_APPVIEW}/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(
+        handle,
+      )}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!res.ok) return null;
+    const d = (await res.json()) as { did?: string };
+    return d.did ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve every `@handle` in `text` to a mention facet (UTF-8 byte range → DID).
+ * Handles that don't resolve are silently dropped. Resolution is cached per call
+ * so a handle mentioned twice is only fetched once.
+ */
+export async function resolveMentionFacets(text: string): Promise<Mention[]> {
+  const spans = detectMentionSpans(text);
+  if (spans.length === 0) return [];
+
+  const cache = new Map<string, string | null>();
+  const resolve = async (handle: string): Promise<string | null> => {
+    const key = handle.toLowerCase();
+    if (cache.has(key)) return cache.get(key)!;
+    const did = await resolveHandle(handle);
+    cache.set(key, did);
+    return did;
+  };
+
+  const facets: Mention[] = [];
+  for (const span of spans) {
+    const did = await resolve(span.handle);
+    if (!did) continue;
+    facets.push({
+      did,
+      byteStart: byteLength(text.slice(0, span.start)),
+      byteEnd: byteLength(text.slice(0, span.end)),
+    });
+  }
+  return facets;
+}
+
+export type Segment =
+  | { type: "text"; value: string }
+  | { type: "mention"; value: string; target: string }
+  | { type: "link"; value: string; href: string };
+
+/** Matches http(s) URLs; the capture excludes common trailing punctuation. */
+const URL_RE = /https?:\/\/[^\s<]+[^\s<.,:;!?)\]}'"]/g;
+
+/** Split a plain-text run into text + link segments (URLs → clickable). */
+function splitLinks(text: string): Segment[] {
+  const out: Segment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    const start = m.index ?? 0;
+    const url = m[0];
+    if (start > last) out.push({ type: "text", value: text.slice(last, start) });
+    out.push({ type: "link", value: url, href: url });
+    last = start + url.length;
+  }
+  if (last < text.length) out.push({ type: "text", value: text.slice(last) });
+  return out;
+}
+
+/** Regex-based mention + link segmentation, used when a shout has no facets. */
+function segmentWithoutFacets(text: string): Segment[] {
+  const spans = detectMentionSpans(text);
+  if (spans.length === 0) return splitLinks(text);
+  const out: Segment[] = [];
+  let cursor = 0;
+  for (const span of spans) {
+    if (span.start > cursor) {
+      out.push(...splitLinks(text.slice(cursor, span.start)));
+    }
+    out.push({
+      type: "mention",
+      value: text.slice(span.start, span.end),
+      target: span.handle,
+    });
+    cursor = span.end;
+  }
+  if (cursor < text.length) out.push(...splitLinks(text.slice(cursor)));
+  return out;
+}
+
+/**
+ * Split a shout's message into plain + mention + link segments. When facets are
+ * present, mentions come from their byte ranges (linking to the DID); otherwise
+ * `@handles` are detected heuristically. URLs are always linkified.
+ */
+export function segmentText(
+  text: string,
+  facets: Mention[] | undefined,
+): Segment[] {
+  if (!facets?.length) return segmentWithoutFacets(text);
+  const bytes = encoder.encode(text);
+  const sorted = [...facets].sort((a, b) => a.byteStart - b.byteStart);
+  const segments: Segment[] = [];
+  let cursor = 0;
+  for (const f of sorted) {
+    if (
+      f.byteStart < cursor ||
+      f.byteEnd > bytes.length ||
+      f.byteEnd <= f.byteStart
+    )
+      continue;
+    if (f.byteStart > cursor) {
+      segments.push(
+        ...splitLinks(decoder.decode(bytes.slice(cursor, f.byteStart))),
+      );
+    }
+    segments.push({
+      type: "mention",
+      value: decoder.decode(bytes.slice(f.byteStart, f.byteEnd)),
+      target: f.did,
+    });
+    cursor = f.byteEnd;
+  }
+  if (cursor < bytes.length) {
+    segments.push(...splitLinks(decoder.decode(bytes.slice(cursor))));
+  }
+  return segments;
+}
+
+export interface ActorSuggestion {
+  did: string;
+  handle: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+/** Typeahead actor search (Bluesky AppView) for the mention autocomplete. */
+export async function searchActorsTypeahead(
+  q: string,
+  limit = 6,
+): Promise<ActorSuggestion[]> {
+  const query = q.trim();
+  if (!query) return [];
+  const url =
+    `${BSKY_APPVIEW}/xrpc/app.bsky.actor.searchActorsTypeahead?q=` +
+    encodeURIComponent(query) +
+    `&limit=${limit}`;
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return [];
+    const d = (await res.json()) as {
+      actors?: {
+        did: string;
+        handle: string;
+        displayName?: string;
+        avatar?: string;
+      }[];
+    };
+    return (d.actors ?? []).map((a) => ({
+      did: a.did,
+      handle: a.handle,
+      displayName: a.displayName,
+      avatar: a.avatar,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** The `@token` the caret currently sits in, for the mention popup. */
+export function activeMentionToken(
+  text: string,
+  caret: number,
+): { start: number; query: string } | null {
+  let i = caret - 1;
+  while (i >= 0) {
+    const ch = text[i];
+    if (ch === "@") {
+      const before = i === 0 ? " " : text[i - 1];
+      if (i === 0 || /[\s(]/.test(before)) {
+        return { start: i, query: text.slice(i + 1, caret) };
+      }
+      return null;
+    }
+    if (!/[a-zA-Z0-9.\-]/.test(ch)) return null;
+    i--;
+  }
+  return null;
+}

--- a/apps/web-mobile/src/pages/shout-editor/ShoutEditor.tsx
+++ b/apps/web-mobile/src/pages/shout-editor/ShoutEditor.tsx
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { PLACEMENT, StatefulPopover } from "baseui/popover";
+import { IconGif, IconX } from "@tabler/icons-react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { isVideoUrl, type MediaResult } from "../../api/klipy";
+import { resolveMentionFacets } from "../../lib/richtext";
 import { profileAtom } from "../../atoms/profile";
 import { shoutsAtom } from "../../atoms/shouts";
+import MediaPicker from "../../components/Shout/MediaPicker";
+import MentionTextarea from "../../components/Shout/MentionTextarea";
 import ShoutList from "../../components/Shout/ShoutList/ShoutList";
 import SignInModal from "../../components/SignInModal";
 import useShout from "../../hooks/useShout";
@@ -22,6 +28,7 @@ export default function ShoutEditor() {
   const setShouts = useSetAtom(shoutsAtom);
   const { shout: postShout, getShouts } = useShout();
   const [message, setMessage] = useState("");
+  const [gif, setGif] = useState<MediaResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [isSignInOpen, setIsSignInOpen] = useState(false);
 
@@ -37,6 +44,16 @@ export default function ShoutEditor() {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,
@@ -49,19 +66,30 @@ export default function ShoutEditor() {
   };
 
   const handleSubmit = async () => {
-    if (!message.trim() || !uri || loading) return;
+    if ((!message.trim() && !gif) || !uri || loading) return;
     setLoading(true);
+    const gifEmbed = gif
+      ? {
+          url: gif.url,
+          previewUrl: gif.previewUrl,
+          alt: gif.alt,
+          width: gif.width,
+          height: gif.height,
+        }
+      : undefined;
     try {
-      await postShout(uri, message);
+      const facets = message.trim() ? await resolveMentionFacets(message) : [];
+      await postShout(uri, message, gifEmbed, facets.length ? facets : undefined);
       const data = await getShouts(uri);
       setShouts({ ...shouts, [uri]: processShouts(data) });
       setMessage("");
+      setGif(null);
     } finally {
       setLoading(false);
     }
   };
 
-  const canPost = message.trim() && !loading;
+  const canPost = (message.trim() || gif) && !loading;
 
   return (
     <div className="min-h-screen bg-[var(--color-background)] pb-[calc(16px+env(safe-area-inset-bottom))]">
@@ -102,17 +130,96 @@ export default function ShoutEditor() {
         )}
         {profile && (
           <>
-            <textarea
+            <MentionTextarea
               value={message}
-              onChange={(e) => setMessage(e.target.value)}
+              onChange={setMessage}
               placeholder={`@${profile.handle}, share your thoughts about this ${type}...`}
               maxLength={1000}
-              className="w-full min-h-[80px] resize-y rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-2)] p-3 text-sm font-[inherit] text-[var(--color-text)] outline-none"
+              resize="vertical"
+              overrides={{
+                Root: {
+                  style: {
+                    width: "100%",
+                    borderRadius: "12px",
+                    borderColor: "var(--color-border)",
+                    backgroundColor: "var(--color-surface-2)",
+                  },
+                },
+                InputContainer: {
+                  style: {
+                    backgroundColor: "var(--color-surface-2)",
+                  },
+                },
+                Input: {
+                  style: {
+                    minHeight: "80px",
+                    backgroundColor: "var(--color-surface-2)",
+                    color: "var(--color-text)",
+                    caretColor: "var(--color-text)",
+                    fontFamily: "inherit",
+                    fontSize: "14px",
+                  },
+                },
+              }}
             />
+
+            {gif && (
+              <div className="mt-[10px] relative w-fit max-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-input-background)]">
+                {isVideoUrl(gif.url) ? (
+                  <video
+                    src={gif.url}
+                    className="block h-auto w-full"
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                  />
+                ) : (
+                  <img
+                    src={gif.previewUrl ?? gif.url}
+                    alt={gif.alt ?? ""}
+                    className="block h-auto w-full"
+                  />
+                )}
+                <button
+                  type="button"
+                  aria-label="Remove media"
+                  onClick={() => setGif(null)}
+                  className="absolute right-[6px] top-[6px] flex h-[24px] w-[24px] items-center justify-center rounded-full border-none bg-black/60 text-white cursor-pointer hover:bg-black/80"
+                >
+                  <IconX size={14} />
+                </button>
+              </div>
+            )}
+
             <div className="mt-2 flex items-center justify-between">
-              <span className="text-xs text-[var(--color-text-muted)]">
-                {message.length}/1000
-              </span>
+              <div className="flex items-center gap-3">
+                <StatefulPopover
+                  placement={PLACEMENT.topLeft}
+                  overrides={{ Body: { style: { zIndex: 60 } } }}
+                  content={({ close }) => (
+                    <MediaPicker
+                      onSelect={(m) => {
+                        setGif(m);
+                        close();
+                      }}
+                      onClose={close}
+                    />
+                  )}
+                >
+                  <button
+                    type="button"
+                    aria-label="Add a GIF, sticker or clip"
+                    className="flex items-center gap-[4px] rounded-full border-none bg-transparent px-[10px] py-[5px] text-[13px] text-[var(--color-text-muted)] cursor-pointer hover:bg-[var(--color-input-background)] hover:text-[var(--color-text)]"
+                  >
+                    <IconGif size={20} />
+                    GIF
+                  </button>
+                </StatefulPopover>
+                <span className="text-xs text-[var(--color-text-muted)]">
+                  {message.length}/1000
+                </span>
+              </div>
               <button
                 onClick={handleSubmit}
                 disabled={!canPost}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,3 @@
 VITE_API_URL=http://localhost:3004
 VITE_WS_URL=ws://localhost:8002
+VITE_KLIPY_API_KEY=

--- a/apps/web/src/api/klipy.ts
+++ b/apps/web/src/api/klipy.ts
@@ -1,0 +1,219 @@
+/**
+ * KLIPY media API (GIFs, stickers, clips). Set `VITE_KLIPY_API_KEY` to enable
+ * the picker. https://klipy.com/developers — endpoints follow
+ * `api.klipy.com/api/v1/{key}/{type}/{search|trending}`.
+ *
+ * Note: this API/plan exposes `gifs`, `stickers`, and `clips`. There is no
+ * `memes` route (it 404s "Route not found"), so we don't offer that tab.
+ */
+const KLIPY_KEY = import.meta.env.VITE_KLIPY_API_KEY ?? "";
+const KLIPY_BASE = "https://api.klipy.com/api/v1";
+
+/** True when a key is configured; the picker degrades to a hint otherwise. */
+export const KLIPY_ENABLED = Boolean(KLIPY_KEY);
+
+export type KlipyMediaType = "gifs" | "stickers" | "clips";
+
+export const KLIPY_TABS: { type: KlipyMediaType; label: string }[] = [
+  { type: "gifs", label: "GIFs" },
+  { type: "stickers", label: "Stickers" },
+  { type: "clips", label: "Clips" },
+];
+
+/** The media embed persisted on a shout record (mirrors app.rocksky.shout#gif). */
+export interface GifEmbed {
+  url: string;
+  previewUrl?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+/** A pickable media item: renders in the grid, embeds on select. */
+export interface MediaResult extends GifEmbed {
+  id: string;
+  /** True when `url` is a video (mp4) rather than an image. */
+  isVideo: boolean;
+}
+
+/** True when a URL points at a video the UI should render with <video>. */
+export function isVideoUrl(url: string): boolean {
+  return /\.mp4($|\?)/i.test(url);
+}
+
+interface Rendition {
+  url: string;
+  width?: number;
+  height?: number;
+}
+
+// KLIPY returns two different `file` shapes:
+//  • gifs / stickers — nested by size then format:
+//      file: { md: { gif: {url,width,height}, webp: {...}, mp4: {...} }, ... }
+//  • clips — flat format → url string, with dimensions in a sibling `file_meta`:
+//      file: { mp4: "url", gif: "url", webp: "url" }
+//      file_meta: { mp4: {width,height}, gif: {...}, webp: {...} }
+type NestedRendition = {
+  url?: string;
+  width?: number | string;
+  height?: number | string;
+};
+type NestedFormatMap = Record<string, NestedRendition | undefined>;
+type NestedFile = Record<string, NestedFormatMap | undefined>;
+type FlatFile = Record<string, string | undefined>;
+type MetaMap = Record<
+  string,
+  { width?: number | string; height?: number | string } | undefined
+>;
+
+interface KlipyItem {
+  id?: number | string;
+  slug?: string;
+  title?: string;
+  file?: NestedFile | FlatFile;
+  files?: NestedFile | FlatFile;
+  file_meta?: MetaMap;
+}
+
+const num = (v: number | string | undefined): number | undefined => {
+  const n = typeof v === "string" ? Number(v) : v;
+  return Number.isFinite(n) ? (n as number) : undefined;
+};
+
+/** A `file` whose top-level values are strings is the flat (clips) shape. */
+function isFlatFile(file: NestedFile | FlatFile): file is FlatFile {
+  return Object.values(file).some((v) => typeof v === "string");
+}
+
+/** Flat (clips) shape → renditions from format→url strings + `file_meta` dims. */
+function pickFlat(
+  file: FlatFile,
+  meta: MetaMap | undefined,
+  wantVideo: boolean,
+): { full?: Rendition; preview?: Rendition } {
+  const at = (fmt: string): Rendition | undefined => {
+    const url = file[fmt];
+    if (typeof url !== "string" || !url) return undefined;
+    const m = meta?.[fmt];
+    return { url, width: num(m?.width), height: num(m?.height) };
+  };
+  const fullFmts = wantVideo ? ["mp4", "webp", "gif"] : ["gif", "webp", "mp4"];
+  let full: Rendition | undefined;
+  for (const f of fullFmts) if (!full) full = at(f);
+  let preview: Rendition | undefined;
+  for (const f of ["gif", "webp", "jpg", "png"]) if (!preview) preview = at(f);
+  return { full, preview };
+}
+
+/** Nested (gifs/stickers) shape → walk size then format. */
+function pickNested(
+  file: NestedFile,
+  wantVideo: boolean,
+): { full?: Rendition; preview?: Rendition } {
+  const sizes = ["md", "sm", "hd", "lg", "xs"];
+  const fullFmts = wantVideo ? ["mp4", "webp", "gif"] : ["gif", "webp", "mp4"];
+  const previewFmts = ["webp", "gif", "png", "jpg"];
+  const norm = (r: NestedRendition | undefined): Rendition | undefined =>
+    r?.url ? { url: r.url, width: num(r.width), height: num(r.height) } : undefined;
+
+  let full: Rendition | undefined;
+  for (const s of sizes) {
+    const fm = file[s];
+    if (!fm) continue;
+    for (const f of fullFmts) if (!full) full = norm(fm[f]);
+    if (full) break;
+  }
+  let preview: Rendition | undefined;
+  for (const s of ["sm", "md", "hd", "xs"]) {
+    const fm = file[s];
+    if (!fm) continue;
+    for (const f of previewFmts) if (!preview) preview = norm(fm[f]);
+    if (preview) break;
+  }
+  return { full, preview };
+}
+
+function toResult(item: KlipyItem, type: KlipyMediaType): MediaResult | null {
+  const wantVideo = type === "clips";
+  const file = item.file ?? item.files;
+  if (!file) return null;
+  const { full, preview } = isFlatFile(file)
+    ? pickFlat(file, item.file_meta, wantVideo)
+    : pickNested(file, wantVideo);
+  if (!full?.url) return null;
+  return {
+    id: String(item.id ?? item.slug ?? full.url),
+    url: full.url,
+    previewUrl: preview?.url ?? full.url,
+    alt: item.title?.trim() || item.slug || undefined,
+    width: full.width,
+    height: full.height,
+    isVideo: isVideoUrl(full.url),
+  };
+}
+
+/** A stable per-browser id KLIPY uses to personalize trending/recents. */
+function customerId(): string {
+  try {
+    const key = "rocksky:klipy-cid";
+    let v = localStorage.getItem(key);
+    if (!v) {
+      v = Math.random().toString(36).slice(2) + Date.now().toString(36);
+      localStorage.setItem(key, v);
+    }
+    return v;
+  } catch {
+    return "anon";
+  }
+}
+
+async function request(
+  type: KlipyMediaType,
+  action: "search" | "trending",
+  params: URLSearchParams,
+): Promise<MediaResult[]> {
+  if (!KLIPY_KEY) return [];
+  params.set("customer_id", customerId());
+  const url = `${KLIPY_BASE}/${encodeURIComponent(KLIPY_KEY)}/${type}/${action}?${params}`;
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      data?: { data?: KlipyItem[] } | KlipyItem[];
+    };
+    const list = Array.isArray(json.data)
+      ? json.data
+      : (json.data?.data ?? []);
+    return list
+      .map((it) => toResult(it, type))
+      .filter((r): r is MediaResult => r !== null);
+  } catch {
+    return [];
+  }
+}
+
+/** Search KLIPY media of a given type; empty query → trending. */
+export function searchMedia(
+  type: KlipyMediaType,
+  q: string,
+  perPage = 24,
+): Promise<MediaResult[]> {
+  const query = q.trim();
+  if (!query) {
+    return request(
+      type,
+      "trending",
+      new URLSearchParams({ page: "1", per_page: String(perPage) }),
+    );
+  }
+  return request(
+    type,
+    "search",
+    new URLSearchParams({ q: query, page: "1", per_page: String(perPage) }),
+  );
+}
+
+/** Adapt a stored gif embed back into the picker's MediaResult shape. */
+export function gifEmbedToMedia(g: GifEmbed): MediaResult {
+  return { ...g, id: g.url, isVideo: isVideoUrl(g.url) };
+}

--- a/apps/web/src/api/shouts.ts
+++ b/apps/web/src/api/shouts.ts
@@ -1,10 +1,17 @@
 import axios from "axios";
+import type { GifEmbed } from "./klipy";
+import type { Mention } from "../lib/richtext";
 import { API_URL } from "../consts";
 
-export const shout = async (uri: string, message: string) => {
+export const shout = async (
+  uri: string,
+  message: string,
+  gif?: GifEmbed,
+  facets?: Mention[],
+) => {
   const response = await axios.post(
     `${API_URL}/users/${uri.replace("at://", "")}/shouts`,
-    { message },
+    { message, gif, facets },
     {
       headers: {
         "Content-Type": "application/json",
@@ -27,10 +34,15 @@ export const getShouts = async (uri: string) => {
   return response.data;
 };
 
-export const reply = async (uri: string, message: string) => {
+export const reply = async (
+  uri: string,
+  message: string,
+  gif?: GifEmbed,
+  facets?: Mention[],
+) => {
   const response = await axios.post(
     `${API_URL}/users/${uri.replace("at://", "")}/replies`,
-    { message },
+    { message, gif, facets },
     {
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/components/Shout/MediaPicker/MediaPicker.tsx
+++ b/apps/web/src/components/Shout/MediaPicker/MediaPicker.tsx
@@ -1,0 +1,247 @@
+import styled from "@emotion/styled";
+import { IconSearch, IconX } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  KLIPY_ENABLED,
+  KLIPY_TABS,
+  searchMedia,
+  type KlipyMediaType,
+  type MediaResult,
+} from "../../../api/klipy";
+
+const Panel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 340px;
+  max-width: calc(100vw - 32px);
+  padding: 12px;
+  border-radius: 12px;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-input-background);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+`;
+
+const TopBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Tabs = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+const Tab = styled.button<{ active: boolean }>`
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: all 0.15s ease;
+  background-color: ${({ active }) =>
+    active ? "var(--color-purple)" : "transparent"};
+  color: ${({ active }) =>
+    active ? "var(--color-button-text)" : "var(--color-text-muted)"};
+
+  &:hover {
+    color: var(--color-text);
+  }
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  width: 28px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background-color: transparent;
+  color: var(--color-text-muted);
+
+  &:hover {
+    background-color: var(--color-input-background);
+    color: var(--color-text);
+  }
+`;
+
+const SearchBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-radius: 8px;
+  background-color: var(--color-input-background);
+`;
+
+const SearchInput = styled.input`
+  height: 34px;
+  width: 100%;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  font-size: 14px;
+  color: var(--color-text);
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  height: 300px;
+  align-content: start;
+  overflow-y: auto;
+`;
+
+const Tile = styled.button`
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--color-input-background);
+  cursor: pointer;
+  padding: 0;
+  background-color: var(--color-input-background);
+  transition: transform 0.12s ease;
+
+  &:hover {
+    transform: scale(1.03);
+    border-color: var(--color-purple);
+  }
+
+  & > img,
+  & > video {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
+
+const Empty = styled.div`
+  grid-column: span 3;
+  padding: 32px 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-text-muted);
+`;
+
+const Credit = styled.p`
+  margin: 0;
+  text-align: center;
+  font-size: 10px;
+  color: var(--color-text-muted);
+`;
+
+/** Debounce a fast-changing value. */
+function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+interface MediaPickerProps {
+  onSelect: (media: MediaResult) => void;
+  onClose: () => void;
+}
+
+/** KLIPY-powered GIF / sticker / clip picker. */
+function MediaPicker({ onSelect, onClose }: MediaPickerProps) {
+  const [type, setType] = useState<KlipyMediaType>("gifs");
+  const [query, setQuery] = useState("");
+  const debounced = useDebounced(query, 350);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  const { data, isFetching } = useQuery({
+    queryKey: ["klipy", type, debounced],
+    queryFn: () => searchMedia(type, debounced),
+    enabled: KLIPY_ENABLED,
+    staleTime: 60_000,
+  });
+
+  const results = data ?? [];
+
+  return (
+    <Panel onClick={(e) => e.stopPropagation()}>
+      <TopBar>
+        <Tabs>
+          {KLIPY_TABS.map((tab) => (
+            <Tab
+              key={tab.type}
+              type="button"
+              active={type === tab.type}
+              onClick={() => setType(tab.type)}
+            >
+              {tab.label}
+            </Tab>
+          ))}
+        </Tabs>
+        <CloseButton type="button" aria-label="Close" onClick={onClose}>
+          <IconX size={16} />
+        </CloseButton>
+      </TopBar>
+
+      <SearchBox>
+        <IconSearch size={14} color="var(--color-text-muted)" />
+        <SearchInput
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`Search ${type}`}
+        />
+      </SearchBox>
+
+      <Grid>
+        {!KLIPY_ENABLED ? (
+          <Empty>
+            Set <code>VITE_KLIPY_API_KEY</code> to enable GIFs, stickers &amp;
+            clips.
+          </Empty>
+        ) : results.length === 0 ? (
+          <Empty>{isFetching ? "Loading…" : "No results"}</Empty>
+        ) : (
+          results.map((m) => (
+            <Tile
+              key={m.id}
+              type="button"
+              title={m.alt}
+              onClick={() => onSelect(m)}
+            >
+              {m.isVideo ? (
+                <video
+                  src={m.url}
+                  poster={m.previewUrl}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                />
+              ) : (
+                <img src={m.previewUrl ?? m.url} alt={m.alt ?? ""} loading="lazy" />
+              )}
+            </Tile>
+          ))
+        )}
+      </Grid>
+
+      <Credit>Powered by KLIPY</Credit>
+    </Panel>
+  );
+}
+
+export default MediaPicker;

--- a/apps/web/src/components/Shout/MediaPicker/index.tsx
+++ b/apps/web/src/components/Shout/MediaPicker/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./MediaPicker";

--- a/apps/web/src/components/Shout/MentionTextarea/MentionTextarea.tsx
+++ b/apps/web/src/components/Shout/MentionTextarea/MentionTextarea.tsx
@@ -1,0 +1,228 @@
+import styled from "@emotion/styled";
+import { useQuery } from "@tanstack/react-query";
+import { Textarea, type TextareaProps } from "baseui/textarea";
+import { useEffect, useRef, useState } from "react";
+import { getCaretCoordinates } from "../../../lib/caret";
+import {
+  activeMentionToken,
+  searchActorsTypeahead,
+} from "../../../lib/richtext";
+
+/**
+ * A baseui Textarea with an `@mention` typeahead popup. Fully controlled via
+ * `value`/`onChange`; the popup queries the Bluesky AppView and inserts the
+ * chosen handle. Purely a UI affordance — facets are resolved separately on
+ * submit via `resolveMentionFacets`.
+ */
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const Popup = styled.ul`
+  position: absolute;
+  z-index: 30;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 224px;
+  width: 256px;
+  max-width: calc(100% - 8px);
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid var(--color-input-background);
+  background-color: var(--color-background);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+`;
+
+const Item = styled.button<{ active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  background-color: ${({ active }) =>
+    active ? "var(--color-input-background)" : "transparent"};
+
+  &:hover {
+    background-color: var(--color-input-background);
+  }
+`;
+
+const Avatar = styled.span`
+  display: flex;
+  height: 28px;
+  width: 28px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: 999px;
+  background-color: var(--color-input-background);
+
+  & > img {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+  }
+`;
+
+const Names = styled.span`
+  min-width: 0;
+`;
+
+const DisplayName = styled.span`
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text);
+  font-size: 14px;
+`;
+
+const Handle = styled.span`
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  font-size: 12px;
+`;
+
+/** Debounce a fast-changing value. */
+function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+interface MentionTextareaProps extends Omit<TextareaProps, "onChange"> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function MentionTextarea({ value, onChange, ...rest }: MentionTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [mention, setMention] = useState<{ start: number; query: string } | null>(
+    null,
+  );
+  const [caret, setCaret] = useState<{ top: number; left: number } | null>(null);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const debouncedQuery = useDebounced(mention?.query ?? "", 200);
+
+  const { data: suggestions = [] } = useQuery({
+    queryKey: ["mention-typeahead", debouncedQuery],
+    queryFn: () => searchActorsTypeahead(debouncedQuery),
+    enabled: mention !== null && debouncedQuery.length >= 1,
+    staleTime: 30_000,
+  });
+  const popupOpen = mention !== null && suggestions.length > 0;
+
+  const syncMention = (text: string, caretPos: number) => {
+    const token = activeMentionToken(text, caretPos);
+    setMention(token);
+    setActiveIdx(0);
+    const el = textareaRef.current;
+    if (token && el) {
+      const c = getCaretCoordinates(el, token.start);
+      const maxLeft = Math.max(0, el.clientWidth - 256);
+      setCaret({
+        top: el.offsetTop + c.top + c.height,
+        left: el.offsetLeft + Math.min(c.left, maxLeft),
+      });
+    } else {
+      setCaret(null);
+    }
+  };
+
+  const insertMention = (handle: string) => {
+    if (!mention) return;
+    const el = textareaRef.current;
+    const caretPos = el?.selectionStart ?? value.length;
+    const next =
+      value.slice(0, mention.start) + `@${handle} ` + value.slice(caretPos);
+    onChange(next);
+    setMention(null);
+    setCaret(null);
+    requestAnimationFrame(() => {
+      const pos = mention.start + handle.length + 2;
+      el?.focus();
+      el?.setSelectionRange(pos, pos);
+    });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!popupOpen) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => (i + 1) % suggestions.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => (i - 1 + suggestions.length) % suggestions.length);
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      insertMention(suggestions[activeIdx]!.handle);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setMention(null);
+      setCaret(null);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Textarea
+        inputRef={textareaRef}
+        value={value}
+        onChange={(e) => {
+          onChange(e.currentTarget.value);
+          syncMention(e.currentTarget.value, e.currentTarget.selectionStart ?? 0);
+        }}
+        onClick={(e) =>
+          syncMention(
+            e.currentTarget.value,
+            e.currentTarget.selectionStart ?? 0,
+          )
+        }
+        onKeyUp={(e) =>
+          syncMention(
+            e.currentTarget.value,
+            e.currentTarget.selectionStart ?? 0,
+          )
+        }
+        onKeyDown={onKeyDown}
+        {...rest}
+      />
+
+      {popupOpen && caret && (
+        <Popup style={{ top: caret.top, left: caret.left }}>
+          {suggestions.map((s, i) => (
+            <li key={s.did}>
+              <Item
+                type="button"
+                active={i === activeIdx}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  insertMention(s.handle);
+                }}
+              >
+                <Avatar>{s.avatar && <img src={s.avatar} alt="" />}</Avatar>
+                <Names>
+                  <DisplayName>{s.displayName || s.handle}</DisplayName>
+                  <Handle>@{s.handle}</Handle>
+                </Names>
+              </Item>
+            </li>
+          ))}
+        </Popup>
+      )}
+    </Wrapper>
+  );
+}
+
+export default MentionTextarea;

--- a/apps/web/src/components/Shout/MentionTextarea/index.tsx
+++ b/apps/web/src/components/Shout/MentionTextarea/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./MentionTextarea";

--- a/apps/web/src/components/Shout/RichText.tsx
+++ b/apps/web/src/components/Shout/RichText.tsx
@@ -1,0 +1,64 @@
+import styled from "@emotion/styled";
+import { Link } from "@tanstack/react-router";
+import { Fragment } from "react";
+import { type Mention, segmentText } from "../../lib/richtext";
+
+/**
+ * Renders a shout message as rich text: bare URLs become external links and
+ * `@mentions` become links to the mentioned user's profile. When the shout
+ * carries mention facets the links resolve to the exact DID; otherwise
+ * `@handles` are detected heuristically. Messages are still stored as plain
+ * strings + facets — this is purely presentational.
+ */
+
+const Anchor = styled.a`
+  color: var(--color-primary);
+  text-decoration: none;
+  word-break: break-word;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const MentionLink = styled(Link)`
+  color: var(--color-primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+interface RichTextProps {
+  children: string;
+  facets?: Mention[];
+}
+
+function RichText({ children, facets }: RichTextProps) {
+  const segments = segmentText(children, facets);
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.type === "mention" ? (
+          <MentionLink key={i} to={`/profile/${seg.target}`}>
+            {seg.value}
+          </MentionLink>
+        ) : seg.type === "link" ? (
+          <Anchor
+            key={i}
+            href={seg.href}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {seg.value}
+          </Anchor>
+        ) : (
+          <Fragment key={i}>{seg.value}</Fragment>
+        ),
+      )}
+    </>
+  );
+}
+
+export default RichText;

--- a/apps/web/src/components/Shout/Shout.tsx
+++ b/apps/web/src/components/Shout/Shout.tsx
@@ -2,22 +2,27 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams } from "@tanstack/react-router";
 import { Button } from "baseui/button";
+import { StatefulPopover, PLACEMENT } from "baseui/popover";
 import { Spinner } from "baseui/spinner";
-import { Textarea } from "baseui/textarea";
 import { LabelLarge, LabelMedium } from "baseui/typography";
+import { IconGif, IconX } from "@tabler/icons-react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import z from "zod";
+import { isVideoUrl, type MediaResult } from "../../api/klipy";
+import { resolveMentionFacets } from "../../lib/richtext";
 import { profileAtom } from "../../atoms/profile";
 import { shoutsAtom } from "../../atoms/shouts";
 import { userAtom } from "../../atoms/user";
 import useShout from "../../hooks/useShout";
+import MediaPicker from "./MediaPicker";
+import MentionTextarea from "./MentionTextarea";
 import SignInModal from "../SignInModal";
 import ShoutList from "./ShoutList";
 
 const ShoutSchema = z.object({
-  message: z.string().min(1).max(1000),
+  message: z.string().max(1000),
 });
 
 interface ShoutProps {
@@ -47,8 +52,12 @@ function Shout(props: ShoutProps) {
   const { did, rkey } = useParams({ strict: false });
   const location = window.location;
   const [loading, setLoading] = useState(false);
+  const [gif, setGif] = useState<MediaResult | null>(null);
 
   const onShout = async ({ message }: z.infer<typeof ShoutSchema>) => {
+    if (message.trim().length === 0 && !gif) {
+      return;
+    }
     setLoading(true);
     let uri = "";
 
@@ -72,7 +81,19 @@ function Shout(props: ShoutProps) {
       uri = `at://${did}/app.rocksky.scrobble/${rkey}`;
     }
 
-    await shout(uri, message);
+    const gifEmbed = gif
+      ? {
+          url: gif.url,
+          previewUrl: gif.previewUrl,
+          alt: gif.alt,
+          width: gif.width,
+          height: gif.height,
+        }
+      : undefined;
+
+    const facets = message.trim() ? await resolveMentionFacets(message) : [];
+
+    await shout(uri, message, gifEmbed, facets.length ? facets : undefined);
 
     const data = await getShouts(uri);
     setShouts({
@@ -81,7 +102,7 @@ function Shout(props: ShoutProps) {
     });
 
     setLoading(false);
-
+    setGif(null);
     reset();
   };
 
@@ -97,6 +118,16 @@ function Shout(props: ShoutProps) {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,
@@ -121,8 +152,9 @@ function Shout(props: ShoutProps) {
             name="message"
             control={control}
             render={({ field }) => (
-              <Textarea
-                {...field}
+              <MentionTextarea
+                value={field.value}
+                onChange={field.onChange}
                 placeholder={
                   props.type === "profile"
                     ? `@${profile?.handle}, leave a shout for @${user?.handle} ...`
@@ -156,11 +188,63 @@ function Shout(props: ShoutProps) {
             )}
           />
 
-          <div className="mt-[15px] flex justify-end">
+          {gif && (
+            <div className="mt-[10px] relative w-fit max-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-input-background)]">
+              {isVideoUrl(gif.url) ? (
+                <video
+                  src={gif.url}
+                  className="block w-full h-auto"
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                />
+              ) : (
+                <img
+                  src={gif.previewUrl ?? gif.url}
+                  alt={gif.alt ?? ""}
+                  className="block w-full h-auto"
+                />
+              )}
+              <button
+                type="button"
+                aria-label="Remove media"
+                onClick={() => setGif(null)}
+                className="absolute right-[6px] top-[6px] flex h-[24px] w-[24px] items-center justify-center rounded-full bg-black/60 text-white cursor-pointer border-none hover:bg-black/80"
+              >
+                <IconX size={14} />
+              </button>
+            </div>
+          )}
+
+          <div className="mt-[15px] flex justify-between items-center">
+            <StatefulPopover
+              placement={PLACEMENT.bottomLeft}
+              overrides={{ Body: { style: { zIndex: 3 } } }}
+              content={({ close }) => (
+                <MediaPicker
+                  onSelect={(m) => {
+                    setGif(m);
+                    close();
+                  }}
+                  onClose={close}
+                />
+              )}
+            >
+              <button
+                type="button"
+                aria-label="Add a GIF, sticker or clip"
+                className="flex items-center gap-[4px] rounded-full px-[10px] py-[5px] text-[13px] cursor-pointer border-none bg-transparent text-[var(--color-text-muted)] hover:bg-[var(--color-input-background)] hover:text-[var(--color-text)]"
+              >
+                <IconGif size={20} />
+                GIF
+              </button>
+            </StatefulPopover>
+
             {!loading && (
               <Button
                 disabled={
-                  watch("message").length === 0 ||
+                  (watch("message").length === 0 && !gif) ||
                   watch("message").length > 1000
                 }
                 onClick={handleSubmit(onShout)}

--- a/apps/web/src/components/Shout/ShoutList/Shout/ReplyModal/ReplyModal.tsx
+++ b/apps/web/src/components/Shout/ShoutList/Shout/ReplyModal/ReplyModal.tsx
@@ -9,20 +9,26 @@ import {
   ModalFooter,
   ModalHeader,
 } from "baseui/modal";
+import { StatefulPopover, PLACEMENT } from "baseui/popover";
 import { Spinner } from "baseui/spinner";
-import { Textarea } from "baseui/textarea";
 import { LabelMedium, LabelSmall } from "baseui/typography";
+import { IconGif, IconX } from "@tabler/icons-react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import z from "zod";
+import { isVideoUrl, type MediaResult } from "../../../../../api/klipy";
+import { type Mention, resolveMentionFacets } from "../../../../../lib/richtext";
 import { profileAtom } from "../../../../../atoms/profile";
 import { shoutsAtom } from "../../../../../atoms/shouts";
 import useShout from "../../../../../hooks/useShout";
 import scrollToTop from "../../../../../lib/scrollToTop";
+import MediaPicker from "../../../MediaPicker";
+import MentionTextarea from "../../../MentionTextarea";
+import RichText from "../../../RichText";
 
 const ShoutSchema = z.object({
-  message: z.string().min(1).max(1000),
+  message: z.string().max(1000),
 });
 
 const Link = styled(DefaultLink)`
@@ -54,6 +60,7 @@ interface ReplyModalProps {
   shout: {
     uri: string;
     message: string;
+    facets?: Mention[];
     user: {
       avatar: string;
       displayName: string;
@@ -70,6 +77,7 @@ function ReplyModal(props: ReplyModalProps) {
   const setShouts = useSetAtom(shoutsAtom);
   const { did, rkey } = useParams({ strict: false });
   const [loading, setLoading] = useState(false);
+  const [gif, setGif] = useState<MediaResult | null>(null);
 
   const { control, handleSubmit, reset, watch } = useForm<
     z.infer<typeof ShoutSchema>
@@ -83,14 +91,29 @@ function ReplyModal(props: ReplyModalProps) {
 
   const onClose = () => {
     reset();
+    setGif(null);
     close();
   };
 
   const onReply = async ({ message }: z.infer<typeof ShoutSchema>) => {
+    if (message.trim().length === 0 && !gif) {
+      return;
+    }
     setLoading(true);
-    await reply(shout.uri, message);
+    const gifEmbed = gif
+      ? {
+          url: gif.url,
+          previewUrl: gif.previewUrl,
+          alt: gif.alt,
+          width: gif.width,
+          height: gif.height,
+        }
+      : undefined;
+    const facets = message.trim() ? await resolveMentionFacets(message) : [];
+    await reply(shout.uri, message, gifEmbed, facets.length ? facets : undefined);
     setLoading(false);
     reset();
+    setGif(null);
     close();
 
     let uri = "";
@@ -134,6 +157,16 @@ function ReplyModal(props: ReplyModalProps) {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,
@@ -194,7 +227,8 @@ function ReplyModal(props: ReplyModalProps) {
             onClick={handleSubmit(onReply)}
             shape={"pill"}
             disabled={
-              watch("message").length === 0 || watch("message").length > 1000
+              (watch("message").length === 0 && !gif) ||
+              watch("message").length > 1000
             }
             overrides={{
               BaseButton: {
@@ -255,7 +289,7 @@ function ReplyModal(props: ReplyModalProps) {
               </div>
             </Header>
             <Message className="!text-[var(--color-text)]">
-              {shout.message}
+              <RichText facets={shout.facets}>{shout.message}</RichText>
             </Message>
           </div>
         </div>
@@ -269,7 +303,9 @@ function ReplyModal(props: ReplyModalProps) {
             name="message"
             control={control}
             render={({ field }) => (
-              <Textarea
+              <MentionTextarea
+                value={field.value}
+                onChange={field.onChange}
                 resize="vertical"
                 overrides={{
                   Root: {
@@ -296,13 +332,64 @@ function ReplyModal(props: ReplyModalProps) {
                 autoFocus
                 maxLength={1000}
                 placeholder="Write your reply"
-                {...field}
               />
             )}
           />
         </div>
+
+        {gif && (
+          <div className="ml-[70px] mt-[10px] relative w-fit max-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-input-background)]">
+            {isVideoUrl(gif.url) ? (
+              <video
+                src={gif.url}
+                className="block w-full h-auto"
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            ) : (
+              <img
+                src={gif.previewUrl ?? gif.url}
+                alt={gif.alt ?? ""}
+                className="block w-full h-auto"
+              />
+            )}
+            <button
+              type="button"
+              aria-label="Remove media"
+              onClick={() => setGif(null)}
+              className="absolute right-[6px] top-[6px] flex h-[24px] w-[24px] items-center justify-center rounded-full bg-black/60 text-white cursor-pointer border-none hover:bg-black/80"
+            >
+              <IconX size={14} />
+            </button>
+          </div>
+        )}
       </ModalBody>
-      <ModalFooter></ModalFooter>
+      <ModalFooter className="flex justify-start !mx-[16px]">
+        <StatefulPopover
+          placement={PLACEMENT.topLeft}
+          overrides={{ Body: { style: { zIndex: 3 } } }}
+          content={({ close: closePopover }) => (
+            <MediaPicker
+              onSelect={(m) => {
+                setGif(m);
+                closePopover();
+              }}
+              onClose={closePopover}
+            />
+          )}
+        >
+          <button
+            type="button"
+            aria-label="Add a GIF, sticker or clip"
+            className="flex items-center gap-[4px] rounded-full px-[10px] py-[5px] text-[13px] cursor-pointer border-none bg-transparent text-[var(--color-text-muted)] hover:bg-[var(--color-input-background)] hover:text-[var(--color-text)]"
+          >
+            <IconGif size={20} />
+            GIF
+          </button>
+        </StatefulPopover>
+      </ModalFooter>
     </Modal>
   );
 }

--- a/apps/web/src/components/Shout/ShoutList/Shout/Shout.tsx
+++ b/apps/web/src/components/Shout/ShoutList/Shout/Shout.tsx
@@ -11,8 +11,11 @@ import dayjs from "dayjs";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 import { profileAtom } from "../../../../atoms/profile";
+import { type GifEmbed, isVideoUrl } from "../../../../api/klipy";
+import type { Mention } from "../../../../lib/richtext";
 import useLike from "../../../../hooks/useLike";
 import useShout from "../../../../hooks/useShout";
+import RichText from "../../RichText";
 import HeartOutline from "../../../Icons/HeartOutline";
 import SignInModal from "../../../SignInModal";
 import DeleteShoutModal from "./DeleteShoutModal";
@@ -71,6 +74,22 @@ const Undo = styled.span`
   }
 `;
 
+const MediaEmbed = styled.div`
+  margin-top: 8px;
+  width: fit-content;
+  max-width: 260px;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid var(--color-input-background);
+
+  & > img,
+  & > video {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+`;
+
 interface ShoutProps {
   shout: {
     uri: string;
@@ -79,6 +98,8 @@ interface ShoutProps {
     liked: boolean;
     reported: boolean;
     likes: number;
+    gif?: GifEmbed;
+    facets?: Mention[];
     user: {
       did: string;
       avatar: string;
@@ -212,7 +233,31 @@ function Shout(props: ShoutProps) {
                 </StatefulTooltip>
               </div>
             </Header>
-            <Message>{shout.message}</Message>
+            {shout.message && (
+              <Message>
+                <RichText facets={shout.facets}>{shout.message}</RichText>
+              </Message>
+            )}
+
+            {shout.gif && (
+              <MediaEmbed>
+                {isVideoUrl(shout.gif.url) ? (
+                  <video
+                    src={shout.gif.url}
+                    poster={shout.gif.previewUrl}
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                  />
+                ) : (
+                  <img
+                    src={shout.gif.previewUrl ?? shout.gif.url}
+                    alt={shout.gif.alt ?? ""}
+                  />
+                )}
+              </MediaEmbed>
+            )}
 
             <Actions>
               <ReplyButton onClick={onReply}>

--- a/apps/web/src/components/Shout/ShoutList/ShoutList.tsx
+++ b/apps/web/src/components/Shout/ShoutList/ShoutList.tsx
@@ -73,6 +73,16 @@ function ShoutList() {
           liked: x.shouts.liked,
           reported: x.shouts.reported,
           likes: x.shouts.likes,
+          gif: x.shouts.gifUrl
+            ? {
+                url: x.shouts.gifUrl,
+                previewUrl: x.shouts.gifPreviewUrl,
+                alt: x.shouts.gifAlt,
+                width: x.shouts.gifWidth,
+                height: x.shouts.gifHeight,
+              }
+            : undefined,
+          facets: x.shouts.facets ?? undefined,
           user: {
             did: x.users.did,
             avatar: x.users.avatar,

--- a/apps/web/src/hooks/useShout.tsx
+++ b/apps/web/src/hooks/useShout.tsx
@@ -8,6 +8,8 @@ import {
   reportShout,
   shout,
 } from "../api/shouts";
+import type { GifEmbed } from "../api/klipy";
+import type { Mention } from "../lib/richtext";
 import { API_URL } from "../consts";
 
 export const useShoutMutation = () =>
@@ -46,10 +48,15 @@ export const useCancelReportMutation = () =>
   });
 
 function useShout() {
-  const shout = async (uri: string, message: string) => {
+  const shout = async (
+    uri: string,
+    message: string,
+    gif?: GifEmbed,
+    facets?: Mention[],
+  ) => {
     const response = await axios.post(
       `${API_URL}/users/${uri.replace("at://", "")}/shouts`,
-      { message },
+      { message, gif, facets },
       {
         headers: {
           "Content-Type": "application/json",
@@ -72,10 +79,15 @@ function useShout() {
     return response.data;
   }, []);
 
-  const reply = async (uri: string, message: string) => {
+  const reply = async (
+    uri: string,
+    message: string,
+    gif?: GifEmbed,
+    facets?: Mention[],
+  ) => {
     const response = await axios.post(
       `${API_URL}/users/${uri.replace("at://", "")}/replies`,
-      { message },
+      { message, gif, facets },
       {
         headers: {
           "Content-Type": "application/json",

--- a/apps/web/src/lib/caret.ts
+++ b/apps/web/src/lib/caret.ts
@@ -1,0 +1,75 @@
+/**
+ * Pixel coordinates of the caret within a textarea, relative to the element's
+ * own top-left (padding box). Used to anchor the @-mention popup right under the
+ * text being typed instead of at the bottom of the whole field.
+ *
+ * Works by rendering an invisible "mirror" div that copies the textarea's text
+ * and relevant styles, then measuring a marker placed at the caret offset.
+ */
+const MIRRORED_PROPS = [
+  "boxSizing",
+  "width",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "letterSpacing",
+  "textTransform",
+  "wordSpacing",
+  "lineHeight",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "borderTopWidth",
+  "borderRightWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+  "whiteSpace",
+  "wordWrap",
+  "tabSize",
+] as const;
+
+export interface CaretCoords {
+  /** Offset from the textarea's top edge to the top of the caret line. */
+  top: number;
+  /** Offset from the textarea's left edge to the caret. */
+  left: number;
+  /** Line height at the caret. */
+  height: number;
+}
+
+export function getCaretCoordinates(
+  el: HTMLTextAreaElement,
+  position: number,
+): CaretCoords {
+  const style = window.getComputedStyle(el);
+  const mirror = document.createElement("div");
+
+  mirror.style.position = "absolute";
+  mirror.style.visibility = "hidden";
+  mirror.style.whiteSpace = "pre-wrap";
+  mirror.style.wordWrap = "break-word";
+  mirror.style.top = "0";
+  mirror.style.left = "-9999px";
+  for (const prop of MIRRORED_PROPS) {
+    mirror.style[prop as never] = style[prop as never];
+  }
+  // Overflow must not add scrollbars that shift metrics.
+  mirror.style.overflow = "hidden";
+
+  mirror.textContent = el.value.slice(0, position);
+  // A marker span at the caret; its offset is the caret position.
+  const marker = document.createElement("span");
+  marker.textContent = el.value.slice(position) || ".";
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const top = marker.offsetTop - el.scrollTop;
+  const left = marker.offsetLeft - el.scrollLeft;
+  const height =
+    parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.2;
+  document.body.removeChild(mirror);
+
+  return { top, left, height };
+}

--- a/apps/web/src/lib/richtext.ts
+++ b/apps/web/src/lib/richtext.ts
@@ -1,0 +1,246 @@
+/**
+ * Rich text helpers for shouts: detecting `@mentions`, resolving them to
+ * ATProto mention facets (UTF-8 byte ranges → DID), splitting a message into
+ * renderable segments, and typeahead actor search for the composer.
+ *
+ * Rocksky handles are ATProto/Bluesky handles, so resolution and typeahead go
+ * through the public Bluesky AppView (same as atradio.fm).
+ */
+
+const BSKY_APPVIEW = "https://public.api.bsky.app";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** UTF-8 byte length of a string (facets index by bytes, not code units). */
+function byteLength(s: string): number {
+  return encoder.encode(s).length;
+}
+
+/** A mention facet stored on a shout record. */
+export interface Mention {
+  did: string;
+  byteStart: number;
+  byteEnd: number;
+}
+
+/**
+ * Handle mentions like `@alice.bsky.social`. Matches the leading `@` plus a
+ * dotted handle; the capture excludes any trailing punctuation.
+ */
+const MENTION_RE =
+  /(^|[\s(])@([a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]|[a-zA-Z0-9])/g;
+
+export interface MentionSpan {
+  /** String (code-unit) index of the `@`. */
+  start: number;
+  /** String index just past the handle. */
+  end: number;
+  /** Handle without the leading `@`. */
+  handle: string;
+}
+
+/** Find `@handle` spans in text (string indices). */
+export function detectMentionSpans(text: string): MentionSpan[] {
+  const spans: MentionSpan[] = [];
+  for (const m of text.matchAll(MENTION_RE)) {
+    const lead = m[1] ?? "";
+    const handle = m[2];
+    if (!handle) continue;
+    const at = (m.index ?? 0) + lead.length;
+    spans.push({ start: at, end: at + 1 + handle.length, handle });
+  }
+  return spans;
+}
+
+/** Resolve a single handle to a DID via the public AppView (null on failure). */
+async function resolveHandle(handle: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${BSKY_APPVIEW}/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(
+        handle,
+      )}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!res.ok) return null;
+    const d = (await res.json()) as { did?: string };
+    return d.did ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve every `@handle` in `text` to a mention facet (UTF-8 byte range → DID).
+ * Handles that don't resolve are silently dropped. Resolution is cached per call
+ * so a handle mentioned twice is only fetched once.
+ */
+export async function resolveMentionFacets(text: string): Promise<Mention[]> {
+  const spans = detectMentionSpans(text);
+  if (spans.length === 0) return [];
+
+  const cache = new Map<string, string | null>();
+  const resolve = async (handle: string): Promise<string | null> => {
+    const key = handle.toLowerCase();
+    if (cache.has(key)) return cache.get(key)!;
+    const did = await resolveHandle(handle);
+    cache.set(key, did);
+    return did;
+  };
+
+  const facets: Mention[] = [];
+  for (const span of spans) {
+    const did = await resolve(span.handle);
+    if (!did) continue;
+    facets.push({
+      did,
+      byteStart: byteLength(text.slice(0, span.start)),
+      byteEnd: byteLength(text.slice(0, span.end)),
+    });
+  }
+  return facets;
+}
+
+export type Segment =
+  | { type: "text"; value: string }
+  | { type: "mention"; value: string; target: string }
+  | { type: "link"; value: string; href: string };
+
+/** Matches http(s) URLs; the capture excludes common trailing punctuation. */
+const URL_RE = /https?:\/\/[^\s<]+[^\s<.,:;!?)\]}'"]/g;
+
+/** Split a plain-text run into text + link segments (URLs → clickable). */
+function splitLinks(text: string): Segment[] {
+  const out: Segment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    const start = m.index ?? 0;
+    const url = m[0];
+    if (start > last) out.push({ type: "text", value: text.slice(last, start) });
+    out.push({ type: "link", value: url, href: url });
+    last = start + url.length;
+  }
+  if (last < text.length) out.push({ type: "text", value: text.slice(last) });
+  return out;
+}
+
+/** Regex-based mention + link segmentation, used when a shout has no facets. */
+function segmentWithoutFacets(text: string): Segment[] {
+  const spans = detectMentionSpans(text);
+  if (spans.length === 0) return splitLinks(text);
+  const out: Segment[] = [];
+  let cursor = 0;
+  for (const span of spans) {
+    if (span.start > cursor) {
+      out.push(...splitLinks(text.slice(cursor, span.start)));
+    }
+    out.push({
+      type: "mention",
+      value: text.slice(span.start, span.end),
+      target: span.handle,
+    });
+    cursor = span.end;
+  }
+  if (cursor < text.length) out.push(...splitLinks(text.slice(cursor)));
+  return out;
+}
+
+/**
+ * Split a shout's message into plain + mention + link segments. When facets are
+ * present, mentions come from their byte ranges (linking to the DID); otherwise
+ * `@handles` are detected heuristically. URLs are always linkified.
+ */
+export function segmentText(
+  text: string,
+  facets: Mention[] | undefined,
+): Segment[] {
+  if (!facets?.length) return segmentWithoutFacets(text);
+  const bytes = encoder.encode(text);
+  const sorted = [...facets].sort((a, b) => a.byteStart - b.byteStart);
+  const segments: Segment[] = [];
+  let cursor = 0;
+  for (const f of sorted) {
+    if (
+      f.byteStart < cursor ||
+      f.byteEnd > bytes.length ||
+      f.byteEnd <= f.byteStart
+    )
+      continue;
+    if (f.byteStart > cursor) {
+      segments.push(
+        ...splitLinks(decoder.decode(bytes.slice(cursor, f.byteStart))),
+      );
+    }
+    segments.push({
+      type: "mention",
+      value: decoder.decode(bytes.slice(f.byteStart, f.byteEnd)),
+      target: f.did,
+    });
+    cursor = f.byteEnd;
+  }
+  if (cursor < bytes.length) {
+    segments.push(...splitLinks(decoder.decode(bytes.slice(cursor))));
+  }
+  return segments;
+}
+
+export interface ActorSuggestion {
+  did: string;
+  handle: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+/** Typeahead actor search (Bluesky AppView) for the mention autocomplete. */
+export async function searchActorsTypeahead(
+  q: string,
+  limit = 6,
+): Promise<ActorSuggestion[]> {
+  const query = q.trim();
+  if (!query) return [];
+  const url =
+    `${BSKY_APPVIEW}/xrpc/app.bsky.actor.searchActorsTypeahead?q=` +
+    encodeURIComponent(query) +
+    `&limit=${limit}`;
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return [];
+    const d = (await res.json()) as {
+      actors?: {
+        did: string;
+        handle: string;
+        displayName?: string;
+        avatar?: string;
+      }[];
+    };
+    return (d.actors ?? []).map((a) => ({
+      did: a.did,
+      handle: a.handle,
+      displayName: a.displayName,
+      avatar: a.avatar,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** The `@token` the caret currently sits in, for the mention popup. */
+export function activeMentionToken(
+  text: string,
+  caret: number,
+): { start: number; query: string } | null {
+  let i = caret - 1;
+  while (i >= 0) {
+    const ch = text[i];
+    if (ch === "@") {
+      const before = i === 0 ? " " : text[i - 1];
+      if (i === 0 || /[\s(]/.test(before)) {
+        return { start: i, query: text.slice(i + 1, caret) };
+      }
+      return null;
+    }
+    if (!/[a-zA-Z0-9.\-]/.test(ch)) return null;
+    i--;
+  }
+  return null;
+}


### PR DESCRIPTION
Lexicon (app.rocksky.shout, Pkl-first):
- add a `gif` embed def (url/previewUrl/alt/width/height) and `facets` (mention: did/byteStart/byteEnd); make `message` optional so a shout can carry only a gif. Regenerated JSON + in-app types/registry.

API:
- store gif as flat columns and facets as jsonb on `shouts`; persist both into the PDS record and DB in createShout/replyShout; return them from every shout GET; zod schema + migrations 0016/0017.

web + web-mobile:
- KLIPY-powered MediaPicker (GIFs/stickers/clips) wired into every composer, with a selected-media preview and gif rendering in shout rows.
- @mention typeahead (MentionTextarea, Bluesky AppView actor search, caret- anchored popup) + facet resolution on submit.
- RichText rendering: @mentions link to profiles (by DID when faceted) and http links become clickable, in shout rows and reply previews.