### PR TITLE
feat(onboarding): guide new users on empty profiles, home & upload

### DIFF
--- a/apps/web-mobile/src/components/Onboarding/NewUserGuide.tsx
+++ b/apps/web-mobile/src/components/Onboarding/NewUserGuide.tsx
@@ -1,0 +1,225 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import {
+  IconArrowRight,
+  IconMusic,
+  IconPlayerPlay,
+} from "@tabler/icons-react";
+import { Link } from "react-router-dom";
+import { EXPLORE_STEPS, GET_STARTED_STEPS, type OnboardingStep } from "./steps";
+
+const Wrapper = styled.div`
+  padding-top: 8px;
+`;
+
+const Hero = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 22px;
+  border-radius: 18px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 40, 118, 0.16),
+    rgba(155, 92, 255, 0.14)
+  );
+  border: 1px solid var(--color-border);
+  margin-bottom: 26px;
+`;
+
+const HeroTop = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+`;
+
+const HeroIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: var(--color-primary);
+  color: #fff;
+`;
+
+const HeroTitle = styled.h2`
+  color: var(--color-text);
+  font-size: 19px;
+  margin: 0;
+`;
+
+const HeroText = styled.p`
+  color: var(--color-text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+`;
+
+const HeroButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 13px;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const SectionTitle = styled.div`
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  margin: 0 0 14px;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const cardStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  text-decoration: none;
+`;
+
+const Card = styled(Link)`
+  ${cardStyle}
+`;
+
+const CardExternal = styled.a`
+  ${cardStyle}
+`;
+
+const CardIcon = styled.div<{ accent: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  color: ${({ accent }) => accent};
+  background: ${({ accent }) => `${accent}22`};
+`;
+
+const CardBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const CardTitle = styled.div`
+  color: var(--color-text);
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 3px;
+`;
+
+const CardDesc = styled.div`
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+`;
+
+const Arrow = styled.div`
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+`;
+
+const ExploreRow = styled.div`
+  margin-top: 30px;
+`;
+
+function StepCard({ step }: { step: OnboardingStep }) {
+  const Icon = step.icon;
+  const inner = (
+    <>
+      <CardIcon accent={step.accent}>
+        <Icon size={22} />
+      </CardIcon>
+      <CardBody>
+        <CardTitle>{step.title}</CardTitle>
+        <CardDesc>{step.description}</CardDesc>
+      </CardBody>
+      <Arrow>
+        <IconArrowRight size={18} />
+      </Arrow>
+    </>
+  );
+
+  if (step.external) {
+    return (
+      <CardExternal href={step.to} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </CardExternal>
+    );
+  }
+  return <Card to={step.to}>{inner}</Card>;
+}
+
+export type NewUserGuideProps = {
+  displayName?: string;
+  onShowSteps: () => void;
+};
+
+function NewUserGuide({ displayName, onShowSteps }: NewUserGuideProps) {
+  return (
+    <Wrapper>
+      <Hero>
+        <HeroTop>
+          <HeroIcon>
+            <IconMusic size={28} />
+          </HeroIcon>
+          <div>
+            <HeroTitle>
+              {displayName ? `Welcome, ${displayName}!` : "Welcome to Rocksky!"}
+            </HeroTitle>
+          </div>
+        </HeroTop>
+        <HeroText>
+          This is your music profile. It&apos;s empty for now — connect a source
+          below and it&apos;ll fill up with your scrobbles, top artists and
+          albums.
+        </HeroText>
+        <HeroButton onClick={onShowSteps}>
+          <IconPlayerPlay size={16} /> Show me how to get started
+        </HeroButton>
+      </Hero>
+
+      <SectionTitle>Get your music in</SectionTitle>
+      <List>
+        {GET_STARTED_STEPS.map((step) => (
+          <StepCard key={step.title} step={step} />
+        ))}
+      </List>
+
+      <ExploreRow>
+        <SectionTitle>While you&apos;re here</SectionTitle>
+        <List>
+          {EXPLORE_STEPS.map((step) => (
+            <StepCard key={step.title} step={step} />
+          ))}
+        </List>
+      </ExploreRow>
+    </Wrapper>
+  );
+}
+
+export default NewUserGuide;

--- a/apps/web-mobile/src/components/Onboarding/OnboardingSheet.tsx
+++ b/apps/web-mobile/src/components/Onboarding/OnboardingSheet.tsx
@@ -1,0 +1,211 @@
+import styled from "@emotion/styled";
+import { IconArrowRight, IconSparkles, IconX } from "@tabler/icons-react";
+import { useNavigate } from "react-router-dom";
+import { GET_STARTED_STEPS } from "./steps";
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+`;
+
+const Backdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+`;
+
+const Sheet = styled.div`
+  position: relative;
+  width: 100%;
+  max-height: 88vh;
+  overflow-y: auto;
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  padding: 12px 20px calc(28px + env(safe-area-inset-bottom));
+  background: var(--color-surface);
+`;
+
+const Grip = styled.div`
+  width: 40px;
+  height: 4px;
+  border-radius: 999px;
+  margin: 0 auto 18px;
+  background: var(--color-border);
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  border: none;
+  background: transparent;
+  padding: 4px;
+  cursor: pointer;
+`;
+
+const Badge = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: rgba(255, 40, 118, 0.14);
+  color: var(--color-primary);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+`;
+
+const Title = styled.h2`
+  color: var(--color-text);
+  font-size: 21px;
+  line-height: 1.25;
+  margin: 14px 0 6px;
+`;
+
+const Subtitle = styled.p`
+  color: var(--color-text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 20px;
+`;
+
+const StepList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const StepCard = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  text-align: left;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  cursor: pointer;
+`;
+
+const IconBubble = styled.div<{ accent: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  color: ${({ accent }) => accent};
+  background: ${({ accent }) => `${accent}22`};
+`;
+
+const StepBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const StepTitle = styled.div`
+  color: var(--color-text);
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 2px;
+`;
+
+const StepDesc = styled.div`
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+`;
+
+const Arrow = styled.div`
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+`;
+
+const SkipButton = styled.button`
+  display: block;
+  width: 100%;
+  margin-top: 18px;
+  padding: 12px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  cursor: pointer;
+`;
+
+export type OnboardingSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  displayName?: string;
+};
+
+function OnboardingSheet({ isOpen, onClose, displayName }: OnboardingSheetProps) {
+  const navigate = useNavigate();
+
+  if (!isOpen) return null;
+
+  const go = (step: { to: string; external?: boolean }) => {
+    onClose();
+    if (step.external) {
+      window.open(step.to, "_blank", "noopener,noreferrer");
+      return;
+    }
+    navigate(step.to);
+  };
+
+  return (
+    <Overlay onClick={onClose}>
+      <Backdrop />
+      <Sheet onClick={(e) => e.stopPropagation()}>
+        <Grip />
+        <CloseButton onClick={onClose} aria-label="Close">
+          <IconX size={20} style={{ color: "var(--color-text-muted)" }} />
+        </CloseButton>
+
+        <Badge>
+          <IconSparkles size={13} /> Welcome to Rocksky
+        </Badge>
+        <Title>
+          {displayName ? `Hey ${displayName}, ` : "Hey there, "}
+          let&apos;s fill up your profile
+        </Title>
+        <Subtitle>
+          Your profile is empty for now. Pick one of these to start building
+          your listening history.
+        </Subtitle>
+
+        <StepList>
+          {GET_STARTED_STEPS.map((step) => {
+            const Icon = step.icon;
+            return (
+              <StepCard key={step.title} onClick={() => go(step)}>
+                <IconBubble accent={step.accent}>
+                  <Icon size={22} />
+                </IconBubble>
+                <StepBody>
+                  <StepTitle>{step.title}</StepTitle>
+                  <StepDesc>{step.description}</StepDesc>
+                </StepBody>
+                <Arrow>
+                  <IconArrowRight size={18} />
+                </Arrow>
+              </StepCard>
+            );
+          })}
+        </StepList>
+
+        <SkipButton onClick={onClose}>I&apos;ll explore on my own</SkipButton>
+      </Sheet>
+    </Overlay>
+  );
+}
+
+export default OnboardingSheet;

--- a/apps/web-mobile/src/components/Onboarding/index.tsx
+++ b/apps/web-mobile/src/components/Onboarding/index.tsx
@@ -1,0 +1,2 @@
+export { default as OnboardingSheet } from "./OnboardingSheet";
+export { default as NewUserGuide } from "./NewUserGuide";

--- a/apps/web-mobile/src/components/Onboarding/steps.tsx
+++ b/apps/web-mobile/src/components/Onboarding/steps.tsx
@@ -1,0 +1,80 @@
+import {
+  IconBroadcast,
+  IconChartBar,
+  IconCloudUpload,
+  IconFileImport,
+  IconKey,
+  IconUsersGroup,
+  type IconProps,
+} from "@tabler/icons-react";
+import type { ComponentType } from "react";
+
+export type OnboardingStep = {
+  icon: ComponentType<IconProps>;
+  title: string;
+  description: string;
+  cta: string;
+  to: string;
+  accent: string;
+  /** When true, `to` is an external URL opened in a new tab. */
+  external?: boolean;
+};
+
+// The primary ways a new user gets their listening data into Rocksky.
+// Note: Spotify is intentionally excluded — it is still limited beta.
+export const GET_STARTED_STEPS: OnboardingStep[] = [
+  {
+    icon: IconBroadcast,
+    title: "Connect a scrobbler",
+    description:
+      "Mirror your plays from Last.fm, ListenBrainz or teal.fm in real time.",
+    cta: "Connect a service",
+    to: "/mirrors",
+    accent: "#ff2876",
+  },
+  {
+    icon: IconFileImport,
+    title: "Import your history",
+    description: "Bring years of listens from a Last.fm or CSV/JSON export.",
+    cta: "Import history",
+    to: "https://docs.rocksky.app/cli/import",
+    external: true,
+    accent: "#00b3ff",
+  },
+  {
+    icon: IconKey,
+    title: "Scrobble from your apps",
+    description: "Create an API key and scrobble from your own music player.",
+    cta: "Create an API key",
+    to: "/apikeys",
+    accent: "#9b5cff",
+  },
+  {
+    icon: IconCloudUpload,
+    title: "Upload your own music",
+    description: "Bring your own tracks and play them right here.",
+    cta: "Upload music",
+    to: "/library/upload",
+    accent: "#1db954",
+  },
+];
+
+// Secondary things to explore once there is some data.
+export const EXPLORE_STEPS: OnboardingStep[] = [
+  {
+    icon: IconChartBar,
+    title: "Discover the charts",
+    description: "See what the community is listening to right now.",
+    cta: "Browse charts",
+    to: "/charts",
+    accent: "#ffb020",
+  },
+  {
+    icon: IconUsersGroup,
+    title: "Find your people",
+    description: "Follow friends and compare your music taste.",
+    cta: "Explore Rocksky",
+    to: "/",
+    accent: "#ff6ba8",
+  },
+];

--- a/apps/web-mobile/src/hooks/useProfile.tsx
+++ b/apps/web-mobile/src/hooks/useProfile.tsx
@@ -74,6 +74,12 @@ function useProfile(token?: string | null) {
         window.location.href = "/";
         return;
       }
+      // Keep the logged-in DID in localStorage so own-profile detection
+      // (follow button, onboarding, welcome banner) is reliable and synchronous
+      // across the layout remounts that happen on every navigation.
+      if (profile.did) {
+        localStorage.setItem("did", profile.did);
+      }
       setProfile({
         avatar: profile.avatar,
         displayName: profile.displayName,

--- a/apps/web-mobile/src/pages/apikeys/index.tsx
+++ b/apps/web-mobile/src/pages/apikeys/index.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus } from "@styled-icons/evaicons-solid";
+import { IconHelpCircle } from "@tabler/icons-react";
 import { Copy, Trash } from "@styled-icons/ionicons-outline";
 import { Button } from "baseui/button";
 import { Input } from "baseui/input";
@@ -229,6 +230,26 @@ export default function ApiKeysPage() {
           >
             New API Key
           </Button>
+        </div>
+
+        <div
+          className="flex items-center gap-2 mb-5 text-sm"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          <IconHelpCircle size={16} className="shrink-0" />
+          <span>
+            Need help using your API Application keys?{" "}
+            <a
+              href="https://docs.rocksky.app/integrations"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold no-underline"
+              style={{ color: "var(--color-primary)" }}
+            >
+              Read the integrations guide
+            </a>
+            .
+          </span>
         </div>
 
         {apiKeys.data?.length === 0 && (

--- a/apps/web-mobile/src/pages/library/upload.tsx
+++ b/apps/web-mobile/src/pages/library/upload.tsx
@@ -2,6 +2,7 @@ import {
   IconCheck,
   IconCloudUpload,
   IconMusic,
+  IconServer,
   IconX,
 } from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
@@ -122,6 +123,48 @@ export default function UploadPage() {
         >
           <span style={{ color: "var(--color-text)", fontWeight: 600 }}>Required metadata</span>
           {" — "}Title · Artist · Album · Album artist · Duration · Album art
+        </div>
+
+        {/* Streaming info */}
+        <div
+          className="flex items-start gap-3 rounded-xl p-4 mb-5 text-sm"
+          style={{
+            backgroundColor: "color-mix(in srgb, var(--color-primary) 8%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--color-primary) 20%, transparent)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <IconServer
+            size={18}
+            className="shrink-0 mt-0.5"
+            style={{ color: "var(--color-primary)" }}
+          />
+          <div>
+            <span style={{ color: "var(--color-text)", fontWeight: 600 }}>
+              Stream it anywhere
+            </span>
+            {" — "}Music you upload can be played through any Navidrome or
+            Subsonic-compatible client, or the{" "}
+            <a
+              href="https://docs.rocksky.app/cli/overview"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline font-semibold"
+              style={{ color: "var(--color-primary)" }}
+            >
+              @rocksky/cli
+            </a>
+            .{" "}
+            <a
+              href="https://docs.rocksky.app/integrations/navidrome-server"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline font-semibold"
+              style={{ color: "var(--color-primary)" }}
+            >
+              Learn more
+            </a>
+          </div>
         </div>
 
         {/* File picker */}

--- a/apps/web-mobile/src/pages/profile/Profile.tsx
+++ b/apps/web-mobile/src/pages/profile/Profile.tsx
@@ -8,11 +8,12 @@ import { Avatar } from "baseui/avatar";
 import ContentLoader from "react-content-loader";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import numeral from "numeral";
 import { followsAtom } from "../../atoms/follows";
+import { profileAtom } from "../../atoms/profile";
 import Main from "../../layouts/Main";
 import {
   useFollowAccountMutation,
@@ -36,6 +37,7 @@ import {
 } from "../../hooks/useLibrary";
 import ShareOnBluesky from "../../components/ShareOnBluesky";
 import FloatingShoutBar from "../../components/FloatingShoutBar";
+import { NewUserGuide, OnboardingSheet } from "../../components/Onboarding";
 import { ALL_TIME, LAST_7_DAYS, RANGE_LABELS, RANGE_OPTIONS } from "../../consts";
 import { getLastDays } from "../../lib/date";
 
@@ -929,8 +931,10 @@ const TABS = ["Overview", "Library", "Followers", "Following", "Circles", "Loved
 export default function Profile() {
   const { did } = useParams<{ did: string }>();
   const [activeTab, setActiveTab] = useState(0);
+  const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [follows, setFollows] = useAtom(followsAtom);
   const currentDid = localStorage.getItem("did");
+  const loggedInProfile = useAtomValue(profileAtom);
 
   const { data: profile, isLoading } = useProfileByDidQuery(did!);
   const { data: stats } = useProfileStatsByDidQuery(did);
@@ -967,8 +971,26 @@ export default function Profile() {
   const { mutate: followAccount } = useFollowAccountMutation();
   const { mutate: unfollowAccount } = useUnfollowAccountMutation();
 
-  const isOwnProfile = profile?.did === currentDid;
+  // "My own profile" — match against the stored did OR the logged-in profile
+  // (did/handle), since localStorage "did" is not always set for a session.
+  const isOwnProfile =
+    !!profile?.did &&
+    (profile.did === currentDid ||
+      profile.did === loggedInProfile?.did ||
+      (!!loggedInProfile?.handle && profile.handle === loggedInProfile.handle));
   const isFollowing = follows.has(profile?.did || "");
+  const isNewUser =
+    isOwnProfile && stats !== undefined && (stats?.scrobbles ?? 0) === 0;
+
+  // Auto-open the onboarding sheet once for a brand-new user (empty profile).
+  const ownerId = currentDid || loggedInProfile?.did || profile?.did;
+  useEffect(() => {
+    if (!isNewUser || !ownerId) return;
+    const seenKey = `rocksky:onboarding-seen:${ownerId}`;
+    if (localStorage.getItem(seenKey)) return;
+    setOnboardingOpen(true);
+    localStorage.setItem(seenKey, "1");
+  }, [isNewUser, ownerId]);
 
   const onFollow = () => {
     if (!profile) return;
@@ -1066,40 +1088,57 @@ export default function Profile() {
           )}
         </div>
 
-        {/* Tabs */}
-        <div className="flex overflow-x-auto border-b" style={{ borderColor: "var(--color-border)", scrollbarWidth: "none" }}>
-          {TABS.map((tab, i) => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(i)}
-              className="px-4 py-3 text-sm font-medium whitespace-nowrap border-none bg-transparent cursor-pointer shrink-0"
-              style={{
-                color: activeTab === i ? "var(--color-primary)" : "var(--color-text-muted)",
-                borderBottom: activeTab === i ? "2px solid var(--color-primary)" : "2px solid transparent",
-              }}
-            >
-              {tab}
-            </button>
-          ))}
-        </div>
+        {isNewUser ? (
+          /* New user: guided onboarding instead of empty tabs */
+          <div className="px-4 pt-4" style={{ paddingBottom: "calc(24px + 56px + env(safe-area-inset-bottom))" }}>
+            <NewUserGuide
+              displayName={profile?.displayName}
+              onShowSteps={() => setOnboardingOpen(true)}
+            />
+          </div>
+        ) : (
+          <>
+            {/* Tabs */}
+            <div className="flex overflow-x-auto border-b" style={{ borderColor: "var(--color-border)", scrollbarWidth: "none" }}>
+              {TABS.map((tab, i) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(i)}
+                  className="px-4 py-3 text-sm font-medium whitespace-nowrap border-none bg-transparent cursor-pointer shrink-0"
+                  style={{
+                    color: activeTab === i ? "var(--color-primary)" : "var(--color-text-muted)",
+                    borderBottom: activeTab === i ? "2px solid var(--color-primary)" : "2px solid transparent",
+                  }}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
 
-        {/* Tab content */}
-        <div className="px-4 pt-4" style={{ paddingBottom: "calc(24px + 56px + env(safe-area-inset-bottom))" }}>
-          {(() => {
-            const resolvedDid = profile?.did || did!;
-            return (
-              <>
-                {activeTab === 0 && <OverviewTab did={resolvedDid} />}
-                {activeTab === 1 && <LibraryTab did={resolvedDid} />}
-                {activeTab === 2 && <FollowersTab did={resolvedDid} />}
-                {activeTab === 3 && <FollowingTab did={resolvedDid} />}
-                {activeTab === 4 && <CirclesTab did={resolvedDid} handle={profile?.handle || ""} />}
-                {activeTab === 5 && <LovedTracksTab did={resolvedDid} />}
-              </>
-            );
-          })()}
-        </div>
+            {/* Tab content */}
+            <div className="px-4 pt-4" style={{ paddingBottom: "calc(24px + 56px + env(safe-area-inset-bottom))" }}>
+              {(() => {
+                const resolvedDid = profile?.did || did!;
+                return (
+                  <>
+                    {activeTab === 0 && <OverviewTab did={resolvedDid} />}
+                    {activeTab === 1 && <LibraryTab did={resolvedDid} />}
+                    {activeTab === 2 && <FollowersTab did={resolvedDid} />}
+                    {activeTab === 3 && <FollowingTab did={resolvedDid} />}
+                    {activeTab === 4 && <CirclesTab did={resolvedDid} handle={profile?.handle || ""} />}
+                    {activeTab === 5 && <LovedTracksTab did={resolvedDid} />}
+                  </>
+                );
+              })()}
+            </div>
+          </>
+        )}
       </div>
+      <OnboardingSheet
+        isOpen={onboardingOpen}
+        onClose={() => setOnboardingOpen(false)}
+        displayName={profile?.displayName}
+      />
       <FloatingShoutBar
         uri={`at://${profile?.did || did}`}
         type="profile"

--- a/apps/web/src/components/Onboarding/NewUserGuide.tsx
+++ b/apps/web/src/components/Onboarding/NewUserGuide.tsx
@@ -1,0 +1,232 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Link } from "@tanstack/react-router";
+import {
+  IconArrowRight,
+  IconMusic,
+  IconPlayerPlay,
+} from "@tabler/icons-react";
+import { EXPLORE_STEPS, GET_STARTED_STEPS, type OnboardingStep } from "./steps";
+
+const Wrapper = styled.div`
+  margin-top: 40px;
+`;
+
+const Hero = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 28px;
+  border-radius: 18px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 40, 118, 0.14),
+    rgba(155, 92, 255, 0.12)
+  );
+  border: 1px solid var(--color-border);
+  margin-bottom: 32px;
+`;
+
+const HeroIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  background: var(--color-primary);
+  color: #fff;
+`;
+
+const HeroBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const HeroTitle = styled.h2`
+  color: var(--color-text);
+  font-size: 22px;
+  margin: 0 0 6px;
+`;
+
+const HeroText = styled.p`
+  color: var(--color-text-muted);
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0 0 16px;
+`;
+
+const HeroButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.92;
+  }
+`;
+
+const SectionTitle = styled.div`
+  color: var(--color-text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  margin: 0 0 16px;
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const cardStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  background: var(--color-menu-hover);
+  text-decoration: none;
+  transition: transform 0.12s ease, border-color 0.12s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-primary);
+  }
+`;
+
+const Card = styled(Link)`
+  ${cardStyle}
+`;
+
+const CardExternal = styled.a`
+  ${cardStyle}
+`;
+
+const CardIcon = styled.div<{ accent: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  color: ${({ accent }) => accent};
+  background: ${({ accent }) => `${accent}22`};
+`;
+
+const CardTitle = styled.div`
+  color: var(--color-text);
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const CardDesc = styled.div`
+  color: var(--color-text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  flex: 1;
+`;
+
+const CardCta = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-primary);
+  font-size: 13px;
+  font-weight: 600;
+`;
+
+const ExploreRow = styled.div`
+  margin-top: 36px;
+`;
+
+function StepCard({ step }: { step: OnboardingStep }) {
+  const Icon = step.icon;
+  const inner = (
+    <>
+      <CardIcon accent={step.accent}>
+        <Icon size={22} />
+      </CardIcon>
+      <CardTitle>{step.title}</CardTitle>
+      <CardDesc>{step.description}</CardDesc>
+      <CardCta>
+        {step.cta} <IconArrowRight size={15} />
+      </CardCta>
+    </>
+  );
+
+  if (step.external) {
+    return (
+      <CardExternal href={step.to} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </CardExternal>
+    );
+  }
+  return <Card to={step.to as string}>{inner}</Card>;
+}
+
+export type NewUserGuideProps = {
+  displayName?: string;
+  onShowSteps: () => void;
+};
+
+function NewUserGuide(props: NewUserGuideProps) {
+  const { displayName, onShowSteps } = props;
+
+  return (
+    <Wrapper>
+      <Hero>
+        <HeroIcon>
+          <IconMusic size={32} />
+        </HeroIcon>
+        <HeroBody>
+          <HeroTitle>
+            {displayName ? `Welcome, ${displayName}!` : "Welcome to Rocksky!"}
+          </HeroTitle>
+          <HeroText>
+            This is your music profile. It&apos;s empty for now — connect a
+            source below and it&apos;ll fill up with your scrobbles, top
+            artists, albums and more.
+          </HeroText>
+          <HeroButton onClick={onShowSteps}>
+            <IconPlayerPlay size={16} /> Show me how to get started
+          </HeroButton>
+        </HeroBody>
+      </Hero>
+
+      <SectionTitle>Get your music in</SectionTitle>
+      <Grid>
+        {GET_STARTED_STEPS.map((step) => (
+          <StepCard key={step.title} step={step} />
+        ))}
+      </Grid>
+
+      <ExploreRow>
+        <SectionTitle>While you&apos;re here</SectionTitle>
+        <Grid>
+          {EXPLORE_STEPS.map((step) => (
+            <StepCard key={step.title} step={step} />
+          ))}
+        </Grid>
+      </ExploreRow>
+    </Wrapper>
+  );
+}
+
+export default NewUserGuide;

--- a/apps/web/src/components/Onboarding/OnboardingModal.tsx
+++ b/apps/web/src/components/Onboarding/OnboardingModal.tsx
@@ -1,0 +1,203 @@
+import styled from "@emotion/styled";
+import { useNavigate } from "@tanstack/react-router";
+import { Modal, ModalBody } from "baseui/modal";
+import { IconArrowRight, IconSparkles } from "@tabler/icons-react";
+import { GET_STARTED_STEPS } from "./steps";
+
+const Container = styled.div`
+  padding: 8px 8px 16px;
+`;
+
+const Badge = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 40, 118, 0.12);
+  color: #ff2876;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+`;
+
+const Title = styled.h1`
+  color: var(--color-text);
+  font-size: 26px;
+  line-height: 1.2;
+  margin: 18px 0 6px;
+`;
+
+const Subtitle = styled.p`
+  color: var(--color-text-muted);
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0 0 24px;
+`;
+
+const StepList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const StepCard = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  text-align: left;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: var(--color-menu-hover);
+  cursor: pointer;
+  transition: transform 0.12s ease, border-color 0.12s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    border-color: var(--color-primary);
+  }
+`;
+
+const IconBubble = styled.div<{ accent: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  color: ${({ accent }) => accent};
+  background: ${({ accent }) => `${accent}22`};
+`;
+
+const StepBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const StepTitle = styled.div`
+  color: var(--color-text);
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 3px;
+`;
+
+const StepDesc = styled.div`
+  color: var(--color-text-muted);
+  font-size: 13px;
+  line-height: 1.4;
+`;
+
+const Arrow = styled.div`
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 22px;
+`;
+
+const SkipButton = styled.button`
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-text);
+  }
+`;
+
+export type OnboardingModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  displayName?: string;
+};
+
+function OnboardingModal(props: OnboardingModalProps) {
+  const { isOpen, onClose, displayName } = props;
+  const navigate = useNavigate();
+
+  const go = (step: { to: string; external?: boolean }) => {
+    onClose();
+    if (step.external) {
+      window.open(step.to, "_blank", "noopener,noreferrer");
+      return;
+    }
+    navigate({ to: step.to as string });
+  };
+
+  return (
+    <Modal
+      size="auto"
+      onClose={onClose}
+      isOpen={isOpen}
+      overrides={{
+        Root: { style: { zIndex: 50 } },
+        Dialog: {
+          style: {
+            backgroundColor: "var(--color-background)",
+            maxWidth: "560px",
+            width: "92vw",
+          },
+        },
+        Close: {
+          style: {
+            color: "var(--color-text)",
+            ":hover": { color: "var(--color-text)", opacity: 0.8 },
+          },
+        },
+      }}
+    >
+      <ModalBody style={{ marginTop: 0 }}>
+        <Container>
+          <Badge>
+            <IconSparkles size={14} /> Welcome to Rocksky
+          </Badge>
+          <Title>
+            {displayName ? `Hey ${displayName}, ` : "Hey there, "}
+            let&apos;s get your profile going
+          </Title>
+          <Subtitle>
+            Your profile is empty right now. Pick one of these to start
+            building your listening history — it only takes a minute.
+          </Subtitle>
+
+          <StepList>
+            {GET_STARTED_STEPS.map((step) => {
+              const Icon = step.icon;
+              return (
+                <StepCard key={step.title} onClick={() => go(step)}>
+                  <IconBubble accent={step.accent}>
+                    <Icon size={24} />
+                  </IconBubble>
+                  <StepBody>
+                    <StepTitle>{step.title}</StepTitle>
+                    <StepDesc>{step.description}</StepDesc>
+                  </StepBody>
+                  <Arrow>
+                    <IconArrowRight size={20} />
+                  </Arrow>
+                </StepCard>
+              );
+            })}
+          </StepList>
+
+          <Footer>
+            <SkipButton onClick={onClose}>
+              I&apos;ll explore on my own
+            </SkipButton>
+          </Footer>
+        </Container>
+      </ModalBody>
+    </Modal>
+  );
+}
+
+export default OnboardingModal;

--- a/apps/web/src/components/Onboarding/WelcomeBanner.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeBanner.tsx
@@ -1,0 +1,109 @@
+import styled from "@emotion/styled";
+import { IconPlayerPlay, IconX } from "@tabler/icons-react";
+
+const Banner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(
+    135deg,
+    rgba(255, 40, 118, 0.14),
+    rgba(155, 92, 255, 0.12)
+  );
+  margin-bottom: 20px;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+const Text = styled.div`
+  flex: 1;
+  min-width: 0;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  line-height: 1.45;
+
+  b {
+    color: var(--color-text);
+    font-weight: 700;
+  }
+`;
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+`;
+
+const StartButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    opacity: 0.92;
+  }
+`;
+
+const DismissButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  padding: 6px;
+  cursor: pointer;
+  border-radius: 8px;
+
+  &:hover {
+    color: var(--color-text);
+  }
+`;
+
+export type WelcomeBannerProps = {
+  displayName?: string;
+  onShowSteps: () => void;
+  onDismiss: () => void;
+};
+
+function WelcomeBanner({
+  displayName,
+  onShowSteps,
+  onDismiss,
+}: WelcomeBannerProps) {
+  return (
+    <Banner>
+      <Text>
+        <b>{displayName ? `Welcome, ${displayName}!` : "Welcome to Rocksky!"}</b>{" "}
+        You haven&apos;t scrobbled anything yet — connect a music source to
+        start tracking your listening and build your profile.
+      </Text>
+      <Actions>
+        <StartButton onClick={onShowSteps}>
+          <IconPlayerPlay size={15} /> Show me how to get started
+        </StartButton>
+        <DismissButton onClick={onDismiss} aria-label="Dismiss">
+          <IconX size={18} />
+        </DismissButton>
+      </Actions>
+    </Banner>
+  );
+}
+
+export default WelcomeBanner;

--- a/apps/web/src/components/Onboarding/index.tsx
+++ b/apps/web/src/components/Onboarding/index.tsx
@@ -1,0 +1,3 @@
+export { default as OnboardingModal } from "./OnboardingModal";
+export { default as NewUserGuide } from "./NewUserGuide";
+export { default as WelcomeBanner } from "./WelcomeBanner";

--- a/apps/web/src/components/Onboarding/steps.tsx
+++ b/apps/web/src/components/Onboarding/steps.tsx
@@ -1,0 +1,83 @@
+import {
+  IconBroadcast,
+  IconChartBar,
+  IconCloudUpload,
+  IconFileImport,
+  IconKey,
+  IconUsersGroup,
+  type IconProps,
+} from "@tabler/icons-react";
+import type { ComponentType } from "react";
+
+export type OnboardingStep = {
+  icon: ComponentType<IconProps>;
+  title: string;
+  description: string;
+  cta: string;
+  to: string;
+  accent: string;
+  /** When true, `to` is an external URL opened in a new tab. */
+  external?: boolean;
+};
+
+// The primary ways a new user gets their listening data into Rocksky.
+// Note: Spotify is intentionally excluded — it is still limited beta.
+export const GET_STARTED_STEPS: OnboardingStep[] = [
+  {
+    icon: IconBroadcast,
+    title: "Connect a scrobbler",
+    description:
+      "Mirror your plays from Last.fm, ListenBrainz or teal.fm into Rocksky in real time.",
+    cta: "Connect a service",
+    to: "/mirrors",
+    accent: "#ff2876",
+  },
+  {
+    icon: IconFileImport,
+    title: "Import your history",
+    description:
+      "Already have years of listens? Bring them in from a Last.fm or CSV/JSON export.",
+    cta: "Import history",
+    to: "https://docs.rocksky.app/cli/import",
+    external: true,
+    accent: "#00b3ff",
+  },
+  {
+    icon: IconKey,
+    title: "Scrobble from your apps",
+    description:
+      "Create an API key and scrobble straight from your own music player or scripts.",
+    cta: "Create an API key",
+    to: "/apikeys",
+    accent: "#9b5cff",
+  },
+  {
+    icon: IconCloudUpload,
+    title: "Upload your own music",
+    description:
+      "Bring your own tracks, play them right here, and every listen is scrobbled.",
+    cta: "Upload music",
+    to: "/library/upload",
+    accent: "#1db954",
+  },
+];
+
+// Secondary things to explore once there is some data.
+export const EXPLORE_STEPS: OnboardingStep[] = [
+  {
+    icon: IconChartBar,
+    title: "Discover the charts",
+    description: "See what the whole community is listening to right now.",
+    cta: "Browse charts",
+    to: "/charts",
+    accent: "#ffb020",
+  },
+  {
+    icon: IconUsersGroup,
+    title: "Find your people",
+    description: "Follow friends and see how your music taste compares.",
+    cta: "Explore Rocksky",
+    to: "/",
+    accent: "#ff6ba8",
+  },
+];

--- a/apps/web/src/hooks/useProfile.tsx
+++ b/apps/web/src/hooks/useProfile.tsx
@@ -93,6 +93,12 @@ function useProfile(token?: string | null) {
         window.location.href = "/";
         return;
       }
+      // Keep the logged-in DID in localStorage so own-profile detection
+      // (follow button, onboarding, welcome banner) is reliable and synchronous
+      // across the layout remounts that happen on every navigation.
+      if (profile.did) {
+        localStorage.setItem("did", profile.did);
+      }
       setProfile({
         avatar: profile.avatar,
         displayName: profile.displayName,

--- a/apps/web/src/pages/apikeys/ApiKeys.tsx
+++ b/apps/web/src/pages/apikeys/ApiKeys.tsx
@@ -20,9 +20,10 @@ import {
   useDeleteApikeyMutation,
   useUpdateApikeyMutation,
 } from "../../hooks/useApikey";
+import { IconHelpCircle } from "@tabler/icons-react";
 import Main from "../../layouts/Main";
 import { ApiKey } from "../../types/apikey";
-import { Code, Header } from "./styles";
+import { Code, Header, HelpNote } from "./styles";
 
 const schema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -189,6 +190,20 @@ function ApiKeys() {
             New API Key
           </Button>
         </Header>
+        <HelpNote>
+          <IconHelpCircle size={16} />
+          <span>
+            Need help using your API Application keys?{" "}
+            <a
+              href="https://docs.rocksky.app/integrations"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Read the integrations guide
+            </a>
+            .
+          </span>
+        </HelpNote>
         {apiKeys.isLoading && !apiKeys.data && <ApiKeysSkeleton />}
         <TableBuilder
           data={apiKeys.data}

--- a/apps/web/src/pages/apikeys/styles.tsx
+++ b/apps/web/src/pages/apikeys/styles.tsx
@@ -7,6 +7,26 @@ export const Header = styled.div`
   margin-bottom: 30px;
 `;
 
+export const HelpNote = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: -15px;
+  margin-bottom: 30px;
+  color: var(--color-text-muted);
+  font-size: 14px;
+
+  a {
+    color: var(--color-primary);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  a:hover {
+    opacity: 0.85;
+  }
+`;
+
 export const Code = styled.div`
   background-color: #000;
   color: #fff;

--- a/apps/web/src/pages/home/Home.tsx
+++ b/apps/web/src/pages/home/Home.tsx
@@ -1,15 +1,53 @@
+import { useAtomValue } from "jotai";
+import { useState } from "react";
+import { profileAtom } from "../../atoms/profile";
+import { OnboardingModal, WelcomeBanner } from "../../components/Onboarding";
+import { useProfileStatsByDidQuery } from "../../hooks/useProfile";
 import Main from "../../layouts/Main";
 import Feed from "./feed";
 import Stories from "./stories";
 
 const Home = () => {
   const jwt = localStorage.getItem("token");
+  const loggedInProfile = useAtomValue(profileAtom);
+  const ownerDid = loggedInProfile?.did || localStorage.getItem("did") || "";
+  const stats = useProfileStatsByDidQuery(ownerDid);
+  const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
+  const [dismissed, setDismissed] = useState(
+    () => !!ownerDid && !!localStorage.getItem(`rocksky:home-welcome:${ownerDid}`),
+  );
+
+  const isNewUser =
+    !!jwt &&
+    !!ownerDid &&
+    stats.data !== undefined &&
+    (stats.data?.scrobbles ?? 0) === 0;
+
+  const onDismiss = () => {
+    setDismissed(true);
+    if (ownerDid) {
+      localStorage.setItem(`rocksky:home-welcome:${ownerDid}`, "1");
+    }
+  };
+
   return (
     <Main>
       <div className="mt-[50px]">
+        {isNewUser && !dismissed && (
+          <WelcomeBanner
+            displayName={loggedInProfile?.displayName}
+            onShowSteps={() => setIsOnboardingOpen(true)}
+            onDismiss={onDismiss}
+          />
+        )}
         {jwt && <Stories />}
         <Feed />
       </div>
+      <OnboardingModal
+        isOpen={isOnboardingOpen}
+        onClose={() => setIsOnboardingOpen(false)}
+        displayName={loggedInProfile?.displayName}
+      />
     </Main>
   );
 };

--- a/apps/web/src/pages/library/Upload.tsx
+++ b/apps/web/src/pages/library/Upload.tsx
@@ -3,6 +3,7 @@ import {
   IconCheck,
   IconCloudUpload,
   IconMusic,
+  IconServer,
   IconX,
 } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
@@ -88,6 +89,26 @@ const MetaLink = styled.a`
   &:hover {
     text-decoration: underline;
   }
+`;
+
+const StreamNote = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 0 0 32px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+`;
+
+const StreamIcon = styled.div`
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--color-primary);
 `;
 
 const DropZone = styled.div<{ active: boolean }>`
@@ -370,6 +391,34 @@ export default function UploadPage() {
             is a free, open-source tagger that auto-fills metadata from the MusicBrainz database.
           </div>
         </MetaInfo>
+
+        <StreamNote>
+          <StreamIcon>
+            <IconServer size={18} />
+          </StreamIcon>
+          <div>
+            <strong style={{ color: "var(--color-text)" }}>
+              Stream it anywhere
+            </strong>
+            {" — "}Music you upload can be played through any Navidrome or
+            Subsonic-compatible client, or the{" "}
+            <MetaLink
+              href="https://docs.rocksky.app/cli/overview"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              @rocksky/cli
+            </MetaLink>
+            .{" "}
+            <MetaLink
+              href="https://docs.rocksky.app/integrations/navidrome-server"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more
+            </MetaLink>
+          </div>
+        </StreamNote>
 
         <DropZone {...getRootProps()} active={isDragActive}>
           <input {...getInputProps()} />

--- a/apps/web/src/pages/profile/Profile.tsx
+++ b/apps/web/src/pages/profile/Profile.tsx
@@ -5,13 +5,18 @@ import { Avatar } from "baseui/avatar";
 import { Tab, Tabs } from "baseui/tabs-motion";
 import { HeadingMedium, LabelLarge } from "baseui/typography";
 import dayjs from "dayjs";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import _ from "lodash";
 import { useEffect, useMemo, useState } from "react";
 import { profilesAtom } from "../../atoms/profiles";
+import { profileAtom } from "../../atoms/profile";
 import { userAtom } from "../../atoms/user";
 import Shout from "../../components/Shout/Shout";
-import { useProfileByDidQuery } from "../../hooks/useProfile";
+import {
+  useProfileByDidQuery,
+  useProfileStatsByDidQuery,
+} from "../../hooks/useProfile";
+import { NewUserGuide, OnboardingModal } from "../../components/Onboarding";
 import Main from "../../layouts/Main";
 import Library from "./library";
 import LovedTracks from "./lovedtracks";
@@ -58,6 +63,7 @@ export type ProfileProps = {
 function Profile(props: ProfileProps) {
   const [follows, setFollows] = useAtom(followsAtom);
   const [isSignInOpen, setIsSignInOpen] = useState(false);
+  const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
   const [profiles, setProfiles] = useAtom(profilesAtom);
   const [activeKey, setActiveKey] = useAtom(activeTabAtom);
   const { did } = useParams({ strict: false });
@@ -69,6 +75,20 @@ function Profile(props: ProfileProps) {
   const { mutate: followAccount } = useFollowAccountMutation();
   const { mutate: unfollowAccount } = useUnfollowAccountMutation();
   const currentDid = localStorage.getItem("did");
+  const loggedInProfile = useAtomValue(profileAtom);
+  const profileStats = useProfileStatsByDidQuery(did!);
+  // "My own profile" — match against the stored did OR the logged-in profile
+  // (did/handle), since localStorage "did" is not always set for a session.
+  const isOwnProfile =
+    !!profile.data?.did &&
+    (profile.data.did === currentDid ||
+      profile.data.did === loggedInProfile?.did ||
+      (!!loggedInProfile?.handle &&
+        profile.data.handle === loggedInProfile.handle));
+  const isNewUser =
+    isOwnProfile &&
+    profileStats.data !== undefined &&
+    (profileStats.data?.scrobbles ?? 0) === 0;
   const { data, isLoading } = useFollowersQuery(
     profile.data?.did,
     1,
@@ -162,6 +182,20 @@ function Profile(props: ProfileProps) {
 
     setActiveKey(1);
   }, [tab, setActiveKey]);
+
+  // Auto-open the onboarding modal once for a brand-new user (empty profile).
+  const ownerId = currentDid || loggedInProfile?.did || profile.data?.did;
+  useEffect(() => {
+    if (!isNewUser || !ownerId) {
+      return;
+    }
+    const seenKey = `rocksky:onboarding-seen:${ownerId}`;
+    if (localStorage.getItem(seenKey)) {
+      return;
+    }
+    setIsOnboardingOpen(true);
+    localStorage.setItem(seenKey, "1");
+  }, [isNewUser, ownerId]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <reason>want to run only on profile.data changes</reason>
   useEffect(() => {
@@ -284,8 +318,7 @@ function Profile(props: ProfileProps) {
                   </div>
                 </div>
               </ProfileInfo>
-              {(profile.data?.did !== localStorage.getItem("did") ||
-                !localStorage.getItem("did")) && (
+              {!isOwnProfile && (
                 <>
                   {!follows.has(profile.data?.did || "") && !isLoading && (
                     <Button
@@ -361,125 +394,143 @@ function Profile(props: ProfileProps) {
           </div>
         </div>
 
-        <Tabs
-          activeKey={activeKey}
-          onChange={({ activeKey }) => {
-            setActiveKey(activeKey);
-          }}
-          overrides={{
-            TabHighlight: {
-              style: {
-                backgroundColor: "var(--color-purple)",
-              },
-            },
-            TabBorder: {
-              style: {
-                display: "none",
-              },
-            },
-          }}
-          activateOnFocus
-        >
-          <Tab
-            title="Overview"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
+        {isNewUser ? (
+          <NewUserGuide
+            displayName={
+              profiles[did]?.displayName || profile.data?.displayName
+            }
+            onShowSteps={() => setIsOnboardingOpen(true)}
+          />
+        ) : (
+          <>
+            <Tabs
+              activeKey={activeKey}
+              onChange={({ activeKey }) => {
+                setActiveKey(activeKey);
+              }}
+              overrides={{
+                TabHighlight: {
+                  style: {
+                    backgroundColor: "var(--color-purple)",
+                  },
                 },
-              },
-            }}
-          >
-            <Overview />
-          </Tab>
-          <Tab
-            title="Library"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
+                TabBorder: {
+                  style: {
+                    display: "none",
+                  },
                 },
-              },
-            }}
-          >
-            <Library
-              activeKey={_.get(props, "activeKey", "0").split("/")[1] || "0"}
-            />
-          </Tab>
-          <Tab
-            title="Followers"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
-                },
-              },
-            }}
-          >
-            <Followers />
-          </Tab>
-          <Tab
-            title="Following"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
-                },
-              },
-            }}
-          >
-            <Follows />
-          </Tab>
-          <Tab
-            title="Circles"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
-                },
-              },
-            }}
-          >
-            <Circles />
-          </Tab>
-          <Tab
-            title="Loved Tracks"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
-                },
-              },
-            }}
-          >
-            <LovedTracks />
-          </Tab>
-          <Tab
-            title="Playlists"
-            overrides={{
-              Tab: {
-                style: {
-                  color: "var(--color-text)",
-                  backgroundColor: "var(--color-background) !important",
-                },
-              },
-            }}
-          >
-            <Playlists />
-          </Tab>
-        </Tabs>
-        <Shout type="profile" />
+              }}
+              activateOnFocus
+            >
+              <Tab
+                title="Overview"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <Overview />
+              </Tab>
+              <Tab
+                title="Library"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <Library
+                  activeKey={
+                    _.get(props, "activeKey", "0").split("/")[1] || "0"
+                  }
+                />
+              </Tab>
+              <Tab
+                title="Followers"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <Followers />
+              </Tab>
+              <Tab
+                title="Following"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <Follows />
+              </Tab>
+              <Tab
+                title="Circles"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <Circles />
+              </Tab>
+              <Tab
+                title="Loved Tracks"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <LovedTracks />
+              </Tab>
+              <Tab
+                title="Playlists"
+                overrides={{
+                  Tab: {
+                    style: {
+                      color: "var(--color-text)",
+                      backgroundColor: "var(--color-background) !important",
+                    },
+                  },
+                }}
+              >
+                <Playlists />
+              </Tab>
+            </Tabs>
+            <Shout type="profile" />
+          </>
+        )}
       </div>
       <SignInModal
         isOpen={isSignInOpen}
         onClose={() => setIsSignInOpen(false)}
         follow
+      />
+      <OnboardingModal
+        isOpen={isOnboardingOpen}
+        onClose={() => setIsOnboardingOpen(false)}
+        displayName={profiles[did]?.displayName || profile.data?.displayName}
       />
     </Main>
   );


### PR DESCRIPTION
Web + web-mobile: detect a brand-new user's own empty profile (own profile + 0 scrobbles) and replace the empty/ugly tabs with a guided onboarding experience, plus a first-steps modal that auto-opens once.

- New Onboarding components (@emotion/styled): NewUserGuide inline hero + action cards, OnboardingModal (web) / OnboardingSheet (mobile), and a thin dismissible WelcomeBanner on the web home page.
- Get-started steps: Connect a scrobbler (/mirrors), Import history (docs.rocksky.app/cli/import, new tab), Scrobble from apps (/apikeys), Upload music (/library/upload). Spotify intentionally excluded (beta).
- Robust own-profile detection: match viewed profile against localStorage "did" OR the logged-in profileAtom (did/handle), and persist the logged-in did to localStorage in useProfile so detection is stable across the Main-layout remount on every navigation.
- Fix: Follow button no longer shows on your own profile (web now gates on isOwnProfile instead of a raw localStorage compare).
- apikeys pages: add help link to docs.rocksky.app/integrations.
- Upload screen: "Stream it anywhere" note — uploads play via any Navidrome/Subsonic client or @rocksky/cli, with docs links.