### PR TITLE
Add mention notifications and deep-linking for shouts

### DIFF
--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -13,7 +13,8 @@ export type NotificationType =
   | "comment_scrobble"
   | "comment_profile"
   | "reply"
-  | "react_comment";
+  | "react_comment"
+  | "mention";
 
 export interface CreateNotificationParams {
   /** Recipient user id (users.xata_id). */

--- a/apps/api/src/schema/notifications.ts
+++ b/apps/api/src/schema/notifications.ts
@@ -11,6 +11,7 @@ import users from "./users";
  *  - "comment_profile"  — someone commented on the recipient's profile
  *  - "reply"            — someone replied to the recipient's comment
  *  - "react_comment"    — someone reacted to (liked) the recipient's comment
+ *  - "mention"          — someone @-mentioned the recipient in a shout
  *
  * `userId` is the recipient; `actorId` is the user who triggered the event.
  * `shoutId` / `subjectUri` point at the relevant record so the UI can deep-link.

--- a/apps/api/src/shouts/shouts.service.ts
+++ b/apps/api/src/shouts/shouts.service.ts
@@ -2,7 +2,7 @@ import { type Agent, AtpAgent } from "@atproto/api";
 import { consola } from "consola";
 import { TID } from "@atproto/common";
 import type { Context } from "context";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import * as LikeLexicon from "lexicon/types/app/rocksky/like";
 import * as ShoutLexicon from "lexicon/types/app/rocksky/shout";
 import { validateMain } from "lexicon/types/com/atproto/repo/strongRef";
@@ -17,6 +17,47 @@ import shoutLikes from "../schema/shout-likes";
 import shouts from "../schema/shouts";
 import tracks, { type SelectTrack } from "../schema/tracks";
 import users, { type SelectUser } from "../schema/users";
+
+/**
+ * Notify every user @-mentioned in a shout's facets. Facets carry pre-resolved
+ * DIDs, so we only need to map each DID to its internal users.id. Recipients in
+ * `skipUserIds` are omitted so someone who is both mentioned and, say, the
+ * subject owner or parent-comment author isn't notified twice for one shout.
+ * Self-mentions are dropped by createNotification (actorId === userId).
+ */
+async function notifyMentions(
+  ctx: Context,
+  facets: Shout["facets"],
+  actorId: string,
+  shoutId: string,
+  subjectUri: string,
+  skipUserIds: Array<string | null | undefined> = [],
+) {
+  const dids = [...new Set((facets ?? []).map((f) => f.did))];
+  if (!dids.length) {
+    return;
+  }
+
+  const mentioned = await ctx.db
+    .select({ id: users.id })
+    .from(users)
+    .where(inArray(users.did, dids));
+
+  const skip = new Set(skipUserIds.filter(Boolean));
+
+  for (const m of mentioned) {
+    if (skip.has(m.id)) {
+      continue;
+    }
+    await createNotification(ctx, {
+      userId: m.id,
+      actorId,
+      type: "mention",
+      shoutId,
+      subjectUri,
+    });
+  }
+}
 
 export async function createShout(
   ctx: Context,
@@ -178,6 +219,23 @@ export async function createShout(
         subjectUri: `at://${profile.did}`,
       });
     }
+
+    // Notify anyone @-mentioned in the shout body. Skip the subject owner,
+    // who already got a comment_scrobble/comment_profile notification above.
+    const mentionSubjectUri =
+      scrobble?.scrobble.uri ||
+      track?.uri ||
+      album?.uri ||
+      artist?.uri ||
+      (profile ? `at://${profile.did}` : createdShout.uri);
+    await notifyMentions(
+      ctx,
+      shout.facets,
+      user.id,
+      createdShout.id,
+      mentionSubjectUri,
+      [scrobble?.scrobble.userId, profile?.id],
+    );
   } catch (e) {
     consola.error(`Error creating shout record: ${e.message}`);
   }
@@ -353,14 +411,27 @@ export async function replyShout(
       });
     }
 
-    // Notify the author of the parent comment that someone replied.
+    // Notify the author of the parent comment that someone replied. Deep-link
+    // to the underlying subject page (where the thread renders inline), not the
+    // parent shout's at-uri which has no page of its own.
     await createNotification(ctx, {
       userId: shout.shout.authorId,
       actorId: user.id,
       type: "reply",
       shoutId: createdShout.id,
-      subjectUri: shout.shout.uri,
+      subjectUri,
     });
+
+    // Notify anyone @-mentioned in the reply body. Skip the parent-comment
+    // author, who already got a reply notification above.
+    await notifyMentions(
+      ctx,
+      reply.facets,
+      user.id,
+      createdShout.id,
+      subjectUri,
+      [shout.shout.authorId],
+    );
   } catch (e) {
     consola.error(`Error creating reply record: ${e.message}`);
   }

--- a/apps/web-mobile/src/api/notifications.ts
+++ b/apps/web-mobile/src/api/notifications.ts
@@ -14,7 +14,8 @@ export type NotificationType =
   | "comment_scrobble"
   | "comment_profile"
   | "reply"
-  | "react_comment";
+  | "react_comment"
+  | "mention";
 
 export interface NotificationView {
   id: string;

--- a/apps/web-mobile/src/components/Shout/ShoutList/ShoutList.tsx
+++ b/apps/web-mobile/src/components/Shout/ShoutList/ShoutList.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router";
 import { shoutsAtom } from "../../../atoms/shouts";
 import useShout from "../../../hooks/useShout";
@@ -10,9 +10,11 @@ import "./styles.css";
 function ShoutList({ uri: uriProp }: { uri?: string } = {}) {
   const shouts = useAtomValue(shoutsAtom);
   const setShouts = useSetAtom(shoutsAtom);
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
   const { getShouts } = useShout();
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
+  const [highlightId, setHighlightId] = useState<string | null>(null);
+  const handledHashRef = useRef<string>("");
 
   const shoutKey = uriProp || pathname;
 
@@ -20,6 +22,29 @@ function ShoutList({ uri: uriProp }: { uri?: string } = {}) {
     fetchShouts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getShouts, shoutKey, did, rkey]);
+
+  // Scroll to and briefly highlight a shout deep-linked via `#shout-<id>`
+  // (e.g. from a notification), once its list has loaded into the DOM.
+  useEffect(() => {
+    const raw = (hash ?? "").replace(/^#/, "");
+    if (!raw.startsWith("shout-") || handledHashRef.current === raw) return;
+    if (!(shouts[shoutKey] || []).length) return;
+    const id = raw.slice("shout-".length);
+    const raf = requestAnimationFrame(() => {
+      const el = document.getElementById(`shout-${id}`);
+      if (!el) return;
+      handledHashRef.current = raw;
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      setHighlightId(id);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [shouts, shoutKey, hash]);
+
+  useEffect(() => {
+    if (!highlightId) return;
+    const t = setTimeout(() => setHighlightId(null), 2500);
+    return () => clearTimeout(t);
+  }, [highlightId]);
 
   const fetchShouts = async () => {
     if (uriProp) {
@@ -103,7 +128,13 @@ function ShoutList({ uri: uriProp }: { uri?: string } = {}) {
 
   const renderShout = (shout: any) => {
     return (
-      <div key={shout.id} className="shout-container">
+      <div
+        key={shout.id}
+        id={`shout-${shout.id}`}
+        className={`shout-container rounded-[8px] transition-colors ${
+          highlightId === shout.id ? "bg-[var(--color-menu-hover)]" : ""
+        }`}
+      >
         <Shout shout={shout} refetch={fetchShouts} />
         <div className="replies-container">
           {(shout.replies || []).map((reply: any) => renderShout(reply))}

--- a/apps/web-mobile/src/pages/notifications/index.tsx
+++ b/apps/web-mobile/src/pages/notifications/index.tsx
@@ -16,7 +16,40 @@ const VERB: Record<string, string> = {
   comment_profile: "commented on your profile",
   reply: "replied to your comment",
   react_comment: "reacted to your comment",
+  mention: "mentioned you",
 };
+
+/**
+ * Where a notification navigates. Shouts render inline on their subject page,
+ * so we turn the subject at-uri into that page's path and, when a shout is
+ * involved, tack on a `#shout-<id>` hash that ShoutList scrolls to. Falls back
+ * to the actor's profile for subject-less notifications (e.g. follows).
+ */
+const CONTENT_COLLECTIONS = new Set([
+  "app.rocksky.scrobble",
+  "app.rocksky.song",
+  "app.rocksky.album",
+  "app.rocksky.artist",
+]);
+
+function notificationTarget(n: NotificationView): string {
+  const actor = n.actor;
+  const [did, collection, rkey] = (n.subjectUri?.split("at://")[1] ?? "").split(
+    "/",
+  );
+  let path: string;
+  if (did && collection && CONTENT_COLLECTIONS.has(collection) && rkey) {
+    // "<did>/app.rocksky.<collection>/<rkey>" -> "/<did>/<collection>/<rkey>"
+    path = `/${did}/${collection.replace("app.rocksky.", "")}/${rkey}`;
+  } else if (did) {
+    // Profile subject ("at://<did>" or ".../app.bsky.actor.profile/self").
+    path = `/profile/${did}`;
+  } else {
+    // Subject-less (e.g. follow) — fall back to the actor's profile.
+    path = `/profile/${actor?.handle ?? actor?.did ?? ""}`;
+  }
+  return n.shoutId ? `${path}#shout-${n.shoutId}` : path;
+}
 
 const timeAgo = (iso: string): string => {
   const seconds = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
@@ -38,7 +71,7 @@ function NotificationRow({ notification }: { notification: NotificationView }) {
 
   return (
     <Link
-      to={`/profile/${actor?.handle ?? actor?.did ?? ""}`}
+      to={notificationTarget(notification)}
       className="flex items-start gap-3 px-4 py-3 no-underline"
       style={{ borderBottom: "1px solid var(--color-border)" }}
     >

--- a/apps/web/src/api/notifications.ts
+++ b/apps/web/src/api/notifications.ts
@@ -14,7 +14,8 @@ export type NotificationType =
   | "comment_scrobble"
   | "comment_profile"
   | "reply"
-  | "react_comment";
+  | "react_comment"
+  | "mention";
 
 export interface NotificationView {
   id: string;

--- a/apps/web/src/components/Shout/ShoutList/ShoutList.tsx
+++ b/apps/web/src/components/Shout/ShoutList/ShoutList.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useParams, useRouter } from "@tanstack/react-router";
+import { useParams, useRouter, useRouterState } from "@tanstack/react-router";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { shoutsAtom } from "../../../atoms/shouts";
 import useShout from "../../../hooks/useShout";
 import Shout from "./Shout";
@@ -14,13 +14,39 @@ function ShoutList() {
       location: { pathname },
     },
   } = useRouter();
+  const hash = useRouterState({ select: (s) => s.location.hash });
   const { getShouts } = useShout();
   const { did, rkey } = useParams({ strict: false });
+  const [highlightId, setHighlightId] = useState<string | null>(null);
+  const handledHashRef = useRef<string>("");
 
   useEffect(() => {
     fetchShouts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getShouts, pathname, did, rkey]);
+
+  // Scroll to and briefly highlight a shout deep-linked via `#shout-<id>`
+  // (e.g. from a notification), once its list has loaded into the DOM.
+  useEffect(() => {
+    const raw = (hash ?? "").replace(/^#/, "");
+    if (!raw.startsWith("shout-") || handledHashRef.current === raw) return;
+    if (!(shouts[pathname] || []).length) return;
+    const id = raw.slice("shout-".length);
+    const raf = requestAnimationFrame(() => {
+      const el = document.getElementById(`shout-${id}`);
+      if (!el) return;
+      handledHashRef.current = raw;
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      setHighlightId(id);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [shouts, pathname, hash]);
+
+  useEffect(() => {
+    if (!highlightId) return;
+    const t = setTimeout(() => setHighlightId(null), 2500);
+    return () => clearTimeout(t);
+  }, [highlightId]);
 
   const fetchShouts = async () => {
     let uri = `at://${did}`;
@@ -100,7 +126,10 @@ function ShoutList() {
     return (
       <div
         key={shout.id}
-        className="relative pl-[20px] mb-[20px] before:content-[''] before:absolute before:left-[10px] before:top-0 before:bottom-0 before:w-[2px]"
+        id={`shout-${shout.id}`}
+        className={`relative pl-[20px] mb-[20px] rounded-[8px] transition-colors before:content-[''] before:absolute before:left-[10px] before:top-0 before:bottom-0 before:w-[2px] ${
+          highlightId === shout.id ? "bg-[var(--color-menu-hover)]" : ""
+        }`}
       >
         <Shout shout={shout} refetch={fetchShouts} />
         <div className="ml-[20px] pl-[20px]">

--- a/apps/web/src/layouts/Navbar/NotificationBell.tsx
+++ b/apps/web/src/layouts/Navbar/NotificationBell.tsx
@@ -108,7 +108,40 @@ const VERB: Record<string, string> = {
   comment_profile: "commented on your profile",
   reply: "replied to your comment",
   react_comment: "reacted to your comment",
+  mention: "mentioned you",
 };
+
+/**
+ * Where a notification navigates. Shouts render inline on their subject page,
+ * so we turn the subject at-uri into that page's path and, when a shout is
+ * involved, tack on a `#shout-<id>` hash that ShoutList scrolls to. Falls back
+ * to the actor's profile for subject-less notifications (e.g. follows).
+ */
+const CONTENT_COLLECTIONS = new Set([
+  "app.rocksky.scrobble",
+  "app.rocksky.song",
+  "app.rocksky.album",
+  "app.rocksky.artist",
+]);
+
+function notificationTarget(n: NotificationView): { to: string; hash?: string } {
+  const actor = n.actor;
+  const [did, collection, rkey] = (n.subjectUri?.split("at://")[1] ?? "").split(
+    "/",
+  );
+  let to: string;
+  if (did && collection && CONTENT_COLLECTIONS.has(collection) && rkey) {
+    // "<did>/app.rocksky.<collection>/<rkey>" -> "/<did>/<collection>/<rkey>"
+    to = `/${did}/${collection.replace("app.rocksky.", "")}/${rkey}`;
+  } else if (did) {
+    // Profile subject ("at://<did>" or ".../app.bsky.actor.profile/self").
+    to = `/profile/${did}`;
+  } else {
+    // Subject-less (e.g. follow) — fall back to the actor's profile.
+    to = `/profile/${actor?.handle ?? actor?.did ?? ""}`;
+  }
+  return { to, hash: n.shoutId ? `shout-${n.shoutId}` : undefined };
+}
 
 const timeAgo = (iso: string): string => {
   const seconds = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
@@ -133,12 +166,10 @@ function NotificationRow({
   const name = actor?.displayName || actor?.handle || "Someone";
   const verb = VERB[notification.type] ?? "sent you a notification";
   const isJpegPlaceholder = actor?.avatar?.endsWith("/@jpeg");
+  const { to, hash } = notificationTarget(notification);
 
   return (
-    <Row
-      to={`/profile/${actor?.handle ?? actor?.did ?? ""}`}
-      onClick={onNavigate}
-    >
+    <Row to={to} hash={hash} onClick={onNavigate}>
       {actor?.avatar && !isJpegPlaceholder ? (
         <Avatar src={actor.avatar} name={name} size="36px" />
       ) : (


### PR DESCRIPTION
Shout facets carried resolved mention DIDs but never dispatched notifications. Add a "mention" notification type and a notifyMentions() helper wired into both createShout and replyShout: it maps each facet DID to a users.id and notifies them, skipping the subject owner / parent-comment author (already notified) and self-mentions.

Also make notification rows deep-link to the shout instead of the actor's profile: turn the subject at-uri into its page path plus a #shout-<id> hash, and have ShoutList scroll to and briefly highlight that shout once loaded. replyShout now stores the underlying subject uri (not the parent shout uri) so the link is navigable. Applies to all shout-related notification types; follows still link to the actor.