### PR TITLE
Implement Raycast-style command palette for web search

### DIFF
--- a/apps/web/src/api/search.ts
+++ b/apps/web/src/api/search.ts
@@ -1,9 +1,10 @@
 import axios from "axios";
 import { API_URL } from "../consts";
+import type { SearchResponse } from "../types/search";
 
-export const search = async (query: string) => {
-  const response = await axios.get(
-    `${API_URL}/xrpc/app.rocksky.feed.search?query=${query}&size=100`,
+export const search = async (query: string): Promise<SearchResponse> => {
+  const response = await axios.get<SearchResponse>(
+    `${API_URL}/xrpc/app.rocksky.feed.search?query=${encodeURIComponent(query)}&size=100`,
   );
   return response.data;
 };

--- a/apps/web/src/atoms/searchModal.ts
+++ b/apps/web/src/atoms/searchModal.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+/**
+ * Whether the Raycast-style command-palette search modal is open. Opened by
+ * clicking/focusing the sidebar search input or pressing "/" (see
+ * components/KeyboardShortcuts), rendered once globally from the root route.
+ */
+export const searchModalOpenAtom = atom<boolean>(false);

--- a/apps/web/src/components/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/apps/web/src/components/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -5,6 +5,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useRef } from "react";
 import { playerControlsAtom } from "../../atoms/playerControls";
 import { profileAtom } from "../../atoms/profile";
+import { searchModalOpenAtom } from "../../atoms/searchModal";
 import { shortcutsHelpOpenAtom } from "../../atoms/shortcuts";
 import { themeAtom } from "../../atoms/theme";
 
@@ -26,9 +27,9 @@ const GROUPS: Group[] = [
   {
     title: "General",
     items: [
-      { keys: ["/"], label: "Focus search" },
+      { keys: ["/"], label: "Open search" },
       { keys: ["?"], label: "Show this help" },
-      { keys: ["Esc"], label: "Close dialog / clear search" },
+      { keys: ["Esc"], label: "Close dialog / search" },
       { keys: ["t"], label: "Toggle light / dark theme" },
       { keys: ["e"], label: "Equalizer (audio settings)" },
     ],
@@ -145,24 +146,13 @@ function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
-function focusSearch() {
-  const inputs = Array.from(
-    document.querySelectorAll<HTMLInputElement>("[data-search-input]"),
-  );
-  // Search is rendered twice (drawer + right pane); focus the visible one.
-  const input = inputs.find((el) => el.offsetParent !== null) ?? inputs[0];
-  if (input) {
-    input.focus();
-    input.select();
-  }
-}
-
 function KeyboardShortcuts() {
   const navigate = useNavigate();
   const profile = useAtomValue(profileAtom);
   const controls = useAtomValue(playerControlsAtom);
   const [{ darkMode }, setTheme] = useAtom(themeAtom);
   const [helpOpen, setHelpOpen] = useAtom(shortcutsHelpOpenAtom);
+  const [searchOpen, setSearchOpen] = useAtom(searchModalOpenAtom);
 
   // The keydown listener is installed once; read the latest values through a
   // ref so it never closes over stale state.
@@ -174,6 +164,8 @@ function KeyboardShortcuts() {
     setTheme,
     helpOpen,
     setHelpOpen,
+    searchOpen,
+    setSearchOpen,
   });
   stateRef.current = {
     navigate,
@@ -183,6 +175,8 @@ function KeyboardShortcuts() {
     setTheme,
     helpOpen,
     setHelpOpen,
+    searchOpen,
+    setSearchOpen,
   };
 
   useEffect(() => {
@@ -198,10 +192,11 @@ function KeyboardShortcuts() {
     const onKeyDown = (e: KeyboardEvent) => {
       const s = stateRef.current;
 
-      // Escape closes the help modal (baseui also closes on Escape, but this
+      // Escape closes any open overlay (baseui also closes on Escape, but this
       // covers focus edge-cases and keeps the pending `g` state clean).
       if (e.key === "Escape") {
         if (s.helpOpen) s.setHelpOpen(false);
+        if (s.searchOpen) s.setSearchOpen(false);
         pendingGoAt = 0;
         return;
       }
@@ -234,7 +229,7 @@ function KeyboardShortcuts() {
       switch (e.key) {
         case "/":
           e.preventDefault();
-          focusSearch();
+          s.setSearchOpen(true);
           break;
         case "?":
           e.preventDefault();

--- a/apps/web/src/layouts/Search/Search.tsx
+++ b/apps/web/src/layouts/Search/Search.tsx
@@ -1,31 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import styled from "@emotion/styled";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { Search as SearchIcon } from "@styled-icons/evaicons-solid";
-import { Link as DefaultLink } from "@tanstack/react-router";
 import { Input } from "baseui/input";
-import { PLACEMENT, Popover } from "baseui/popover";
-import _ from "lodash";
-import { useEffect, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-import z from "zod";
-import Artist from "../../components/Icons/Artist";
-import Disc from "../../components/Icons/Disc";
-import Track from "../../components/Icons/Track";
-import { useSearchMutation } from "../../hooks/useSearch";
-import { IconUser } from "@tabler/icons-react";
+import { useSetAtom } from "jotai";
+import { searchModalOpenAtom } from "../../atoms/searchModal";
 
-const Link = styled(DefaultLink)`
-  color: initial;
-  text-decoration: none;
-`;
-
-const Header = styled.div`
-  padding: 16px;
-`;
-
-// "/" affordance shown at the trailing edge of the search input — press "/"
-// anywhere to focus it (see components/KeyboardShortcuts).
+// "/" affordance shown at the trailing edge — press "/" anywhere to open the
+// command palette (see components/KeyboardShortcuts).
 const SlashHint = styled.kbd`
   font-family: var(--font-mono);
   font-size: 12px;
@@ -36,350 +16,73 @@ const SlashHint = styled.kbd`
   border-radius: 6px;
 `;
 
-const schema = z.object({
-  keyword: z.string().nonempty(),
-});
+// The presentational field ignores pointer events so the wrapper handles the
+// click; it exists purely to render the familiar search-box look.
+const Trigger = styled.div`
+  cursor: pointer;
 
+  & > div {
+    pointer-events: none;
+  }
+`;
+
+// The sidebar search field is a trigger: clicking or activating it opens the
+// Raycast-style command palette (see SearchModal) rather than searching inline.
 function Search() {
-  const [results, setResults] = useState<any[]>([]);
-  const { mutate, data } = useSearchMutation();
-
-  const {
-    control,
-    formState: { errors },
-    watch,
-  } = useForm({
-    mode: "onChange",
-    resolver: zodResolver(schema),
-    defaultValues: {
-      keyword: "",
-    },
-  });
-
-  const keyword = watch("keyword");
-
-  const debouncedSearch = _.debounce(async (keyword) => {
-    mutate(keyword);
-  }, 200);
-
-  useEffect(() => {
-    if (keyword.length === 0) {
-      setResults([]);
-    } else if (keyword.length > 1) {
-      debouncedSearch(keyword);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [keyword]);
-
-  useEffect(() => {
-    if (data && data.hits) {
-      setResults(data.hits);
-    } else {
-      setResults([]);
-    }
-  }, [data]);
+  const openSearch = useSetAtom(searchModalOpenAtom);
+  const open = () => openSearch(true);
 
   return (
-    <>
-      <Popover
-        isOpen={keyword.length > 0 && Object.keys(errors).length === 0}
-        content={
-          <div>
-            <Header className="text-[var(--color-text)]">
-              Search for "{keyword}"
-            </Header>
-            {results.length > 0 && (
-              <div className="p-[16px] overflow-y-auto min-h-[54px] !max-h-[400px]">
-                {results.length > 0 && (
-                  <>
-                    {results.map((item: any) => (
-                      <>
-                        {item._federation.indexUid === "users" && (
-                          <Link to={`/profile/${item.handle}`} key={item.id}>
-                            <div className="flex flex-row mb-[10px] mt-[10px]">
-                              {!item.avatar?.endsWith("/@jpeg") && (
-                                <img
-                                  key={item.did}
-                                  src={item.avatar}
-                                  alt={item.displayName}
-                                  className="w-[50px] h-[50px] mr-[12px] rounded-full"
-                                />
-                              )}
-                              {item.avatar?.endsWith("/@jpeg") && (
-                                <div className="min-w-[50px] min-h-[50px] rounded-full bg-[var(--color-avatar-background)] flex items-center justify-center mr-[12px] flex-shrink-0">
-                                  <IconUser size={25} color="#fff" />
-                                </div>
-                              )}
-                              <div className="overflow-hidden">
-                                <div className="overflow-hidden">
-                                  <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[var(--color-text)]">
-                                    {item.displayName}
-                                  </div>
-                                </div>
-                                <div className="overflow-hidden">
-                                  <div
-                                    className="overflow-hidden text-ellipsis whitespace-nowrap text-[var(--color-text-muted)] text-[14px]"
-                                    style={{ fontFamily: "var(--font-mono)" }}
-                                  >
-                                    @{item.handle}
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </Link>
-                        )}
-
-                        {item.uri &&
-                          (item.name || item.title) &&
-                          item._federation.indexUid !== "users" && (
-                            <Link
-                              to={`/${item.uri
-                                ?.split("at://")[1]
-                                .replace("app.rocksky.", "")}`}
-                              key={item.id}
-                            >
-                              <div
-                                key={item.id}
-                                className="h-[64px] flex flex-row items-center"
-                              >
-                                {item._federation.indexUid === "artists" &&
-                                  item.picture && (
-                                    <img
-                                      key={item.id}
-                                      src={item.picture}
-                                      alt={item.name}
-                                      className="w-[50px] h-[50px] mr-[12px] rounded-full"
-                                    />
-                                  )}
-                                {item._federation.indexUid === "artists" &&
-                                  !item.picture && (
-                                    <div
-                                      key={item.id}
-                                      className="w-[50px] h-[50px] mr-[12px] rounded-full flex items-center bg-[rgba(243, 243, 243, 0.725)]"
-                                    >
-                                      <div className="w-[28px] h-[28px]">
-                                        <Artist color="rgba(66, 87, 108, 0.65)" />
-                                      </div>
-                                    </div>
-                                  )}
-                                {item._federation.indexUid === "albums" &&
-                                  item.albumArt && (
-                                    <img
-                                      key={item.id}
-                                      src={item.albumArt}
-                                      alt={item.title}
-                                      className="w-[50px] h-[50px] mr-[12px]"
-                                    />
-                                  )}
-                                {item._federation.indexUid === "albums" &&
-                                  !item.albumArt && (
-                                    <div className="w-[50px] h-[50px] mr-[12px] rounded-full flex items-center bg-[rgba(243, 243, 243, 0.725)]">
-                                      <div className="w-[28px] h-[28px]">
-                                        <Disc
-                                          color="rgba(66, 87, 108, 0.65)"
-                                          width={30}
-                                          height={30}
-                                        />
-                                      </div>
-                                    </div>
-                                  )}
-                                {item._federation.indexUid === "tracks" &&
-                                  item.albumArt && (
-                                    <img
-                                      key={item.id}
-                                      src={item.albumArt}
-                                      alt={item.title}
-                                      className="w-[50px] h-[50px] mr-[12px]"
-                                    />
-                                  )}
-                                {item._federation.indexUid === "tracks" &&
-                                  !item.albumArt && (
-                                    <div className="w-[50px] h-[50px] mr-[12px] rounded-full flex items-center bg-[rgba(243, 243, 243, 0.725)]">
-                                      <div className="w-[28px] h-[28px]">
-                                        <Track color="rgba(66, 87, 108, 0.65)" />
-                                      </div>
-                                    </div>
-                                  )}
-                                <div className="overflow-hidden w-[calc(100%-70px)]">
-                                  <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[var(--color-text)]">
-                                    {item.name || item.title}
-                                  </div>
-                                  {item._federation.indexUid === "tracks" && (
-                                    <div className="text-[14px] text-[var(--color-text-muted)]">
-                                      Track
-                                    </div>
-                                  )}
-                                  {item._federation.indexUid === "albums" && (
-                                    <div className="text-[14px] text-[var(--color-text-muted)]">
-                                      Album
-                                    </div>
-                                  )}
-                                  {item._federation.indexUid === "artists" && (
-                                    <div className="text-[var(--color-text-muted)] text-[14px]">
-                                      Artist
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                            </Link>
-                          )}
-                        {!item.uri &&
-                          (item.name || item.title) &&
-                          item._federation.indexUid !== "users" && (
-                            <div>
-                              <div
-                                key={item.id}
-                                className="h-[64px] flex flex-row items-center"
-                              >
-                                {item._federation.indexUid === "artists" &&
-                                  item.picture && (
-                                    <img
-                                      src={item.picture}
-                                      alt={item.name}
-                                      className="w-[50px] h-[50px] mr-[12px] rounded-full"
-                                    />
-                                  )}
-                                {item._federation.indexUid === "artists" &&
-                                  !item.picture && (
-                                    <div className="w-[50px] h-[50px] mr-[12px] rounded-full flex items-center bg-[rgba(243, 243, 243, 0.725)]">
-                                      <div className="w-[28px] h-[28px]">
-                                        <Artist color="rgba(66, 87, 108, 0.65)" />
-                                      </div>
-                                    </div>
-                                  )}
-                                {item._federation.indexUid === "albums" &&
-                                  item.albumArt && (
-                                    <img
-                                      src={item.albumArt}
-                                      alt={item.title}
-                                      className="w-[50px] h-[50px] mr-[12px]"
-                                    />
-                                  )}
-                                {item._federation.indexUid === "tracks" && (
-                                  <img
-                                    src={item.albumArt}
-                                    alt={item.title}
-                                    className="w-[50px] h-[50px] mr-[12px]"
-                                  />
-                                )}
-                                {["artists", "albums", "tracks"].includes(
-                                  item._federation.indexUid,
-                                ) && (
-                                  <div className="overflow-hidden">
-                                    <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[var(--color-text)]">
-                                      {item.name || item.title}
-                                    </div>
-                                    {item._federation.indexUid === "tracks" && (
-                                      <div className="text-[14px] text-[var(--color-text-muted)]">
-                                        Track
-                                      </div>
-                                    )}
-                                    {item._federation.indexUid === "albums" && (
-                                      <div className="text-[14px] text-[var(--color-text-muted)]">
-                                        Album
-                                      </div>
-                                    )}
-                                    {item._federation.indexUid ===
-                                      "artists" && (
-                                      <div className="text-[14px] text-[var(--color-text-muted)]">
-                                        Artist
-                                      </div>
-                                    )}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          )}
-                      </>
-                    ))}
-                  </>
-                )}
-              </div>
-            )}
-          </div>
+    <Trigger
+      role="button"
+      tabIndex={0}
+      aria-label="Search"
+      onClick={open}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          open();
         }
-        placement={PLACEMENT.bottom}
-        overrides={{
-          Body: {
-            style: {
-              backgroundColor: "var(--color-background)",
-              width: "300px",
-              border: "0.5px solid var(--color-border) !important",
+      }}
+    >
+      <div>
+        <Input
+          readOnly
+          startEnhancer={
+            <SearchIcon size={20} color="var(--color-text-muted)" />
+          }
+          endEnhancer={<SlashHint>/</SlashHint>}
+          placeholder="Search"
+          overrides={{
+            Root: {
+              style: {
+                backgroundColor: "var(--color-input-background)",
+                borderColor: "var(--color-input-background)",
+              },
             },
-          },
-          Inner: {
-            style: {
-              backgroundColor: "var(--color-background)",
+            StartEnhancer: {
+              style: { backgroundColor: "var(--color-input-background)" },
             },
-          },
-        }}
-        popperOptions={{
-          modifiers: {
-            flip: { enabled: false },
-            preventOverflow: { enabled: true },
-          },
-        }}
-      >
-        <div>
-          <Controller
-            name="keyword"
-            control={control}
-            render={({ field }) => (
-              <Input
-                startEnhancer={
-                  <SearchIcon size={20} color="var(--color-text-muted)" />
-                }
-                endEnhancer={
-                  keyword.length > 0 ? undefined : <SlashHint>/</SlashHint>
-                }
-                placeholder="Search"
-                clearable
-                clearOnEscape
-                overrides={{
-                  Root: {
-                    style: {
-                      backgroundColor: "var(--color-input-background)",
-                      borderColor: "var(--color-input-background)",
-                    },
-                  },
-                  StartEnhancer: {
-                    style: {
-                      backgroundColor: "var(--color-input-background)",
-                    },
-                  },
-                  EndEnhancer: {
-                    style: {
-                      backgroundColor: "var(--color-input-background)",
-                      paddingLeft: "0px",
-                    },
-                  },
-                  InputContainer: {
-                    style: {
-                      backgroundColor: "var(--color-input-background)",
-                    },
-                  },
-                  Input: {
-                    style: {
-                      color: "var(--color-text)",
-                      caretColor: "var(--color-text)",
-                    },
-                    props: {
-                      "data-search-input": "true",
-                    },
-                  },
-                  ClearIcon: {
-                    style: {
-                      color: "var(--color-clear-input) !important",
-                    },
-                  },
-                }}
-                {...field}
-              />
-            )}
-          />
-        </div>
-      </Popover>
-    </>
+            EndEnhancer: {
+              style: {
+                backgroundColor: "var(--color-input-background)",
+                paddingLeft: "0px",
+              },
+            },
+            InputContainer: {
+              style: { backgroundColor: "var(--color-input-background)" },
+            },
+            Input: {
+              style: {
+                color: "var(--color-text)",
+                caretColor: "transparent",
+              },
+              props: { tabIndex: -1 },
+            },
+          }}
+        />
+      </div>
+    </Trigger>
   );
 }
 

--- a/apps/web/src/layouts/Search/SearchModal.tsx
+++ b/apps/web/src/layouts/Search/SearchModal.tsx
@@ -1,0 +1,572 @@
+/**
+ * Raycast-style command-palette search for the web app. Opened by clicking the
+ * sidebar search field or pressing "/" (see components/KeyboardShortcuts),
+ * mounted once globally from the root route. Replaces the old inline search
+ * popover. Web only — web-mobile keeps its own search.
+ */
+import styled from "@emotion/styled";
+import { Search as SearchIcon } from "@styled-icons/evaicons-solid";
+import { useNavigate } from "@tanstack/react-router";
+import { IconUser } from "@tabler/icons-react";
+import { useAtom } from "jotai";
+import _ from "lodash";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { searchModalOpenAtom } from "../../atoms/searchModal";
+import Artist from "../../components/Icons/Artist";
+import Disc from "../../components/Icons/Disc";
+import Playlist from "../../components/Icons/Playlist";
+import Track from "../../components/Icons/Track";
+import { useSearchMutation } from "../../hooks/useSearch";
+import {
+  isAlbumHit,
+  isArtistHit,
+  isPlaylistHit,
+  isTrackHit,
+  isUserHit,
+  type SearchHit,
+  type SearchIndex,
+} from "../../types/search";
+
+// ── Result model ────────────────────────────────────────────────────────────
+
+type Art = { url: string | null; round: boolean; kind: SearchIndex };
+
+type NavItem = {
+  id: string;
+  index: SearchIndex;
+  href: string;
+  primary: string;
+  secondary: string | null;
+  secondaryMono: boolean;
+  typeLabel: string;
+  art: Art;
+};
+
+// A broken/placeholder avatar comes back as a URL ending in "/@jpeg".
+const isRealAvatar = (url: string) => !!url && !url.endsWith("/@jpeg");
+
+// Build a display item from a raw hit, resolving its destination path (mirrors
+// the app's routing: users → /profile/<handle>; other records →
+// /<did>/<type>/<rkey> derived from the AT-URI). Returns null when there's no
+// resolvable destination, so it's skipped from the palette.
+function toNavItem(hit: SearchHit): NavItem | null {
+  if (isUserHit(hit)) {
+    if (!hit.handle) return null;
+    return {
+      id: hit.id,
+      index: "users",
+      href: `/profile/${hit.handle}`,
+      primary: hit.displayName || hit.handle,
+      secondary: `@${hit.handle}`,
+      secondaryMono: true,
+      typeLabel: "User",
+      art: {
+        url: isRealAvatar(hit.avatar) ? hit.avatar : null,
+        round: true,
+        kind: "users",
+      },
+    };
+  }
+
+  // Record-backed hits share the AT-URI → path derivation.
+  const href = hit.uri
+    ? `/${hit.uri.split("at://")[1].replace("app.rocksky.", "")}`
+    : null;
+  if (!href) return null;
+
+  if (isArtistHit(hit)) {
+    return {
+      id: hit.id,
+      index: "artists",
+      href,
+      primary: hit.name,
+      secondary: null,
+      secondaryMono: false,
+      typeLabel: "Artist",
+      art: { url: hit.picture, round: true, kind: "artists" },
+    };
+  }
+  if (isAlbumHit(hit)) {
+    return {
+      id: hit.id,
+      index: "albums",
+      href,
+      primary: hit.title,
+      secondary: hit.artist,
+      secondaryMono: false,
+      typeLabel: "Album",
+      art: { url: hit.albumArt, round: false, kind: "albums" },
+    };
+  }
+  if (isTrackHit(hit)) {
+    return {
+      id: hit.id,
+      index: "tracks",
+      href,
+      primary: hit.title,
+      secondary: hit.artist,
+      secondaryMono: false,
+      typeLabel: "Song",
+      art: { url: hit.albumArt, round: false, kind: "tracks" },
+    };
+  }
+  if (isPlaylistHit(hit)) {
+    return {
+      id: hit.id,
+      index: "playlists",
+      href,
+      primary: hit.name,
+      secondary: null,
+      secondaryMono: false,
+      typeLabel: "Playlist",
+      art: { url: hit.picture, round: false, kind: "playlists" },
+    };
+  }
+  return null;
+}
+
+// Section display order + headings.
+const SECTION_ORDER: { index: SearchIndex; label: string }[] = [
+  { index: "tracks", label: "Songs" },
+  { index: "artists", label: "Artists" },
+  { index: "albums", label: "Albums" },
+  { index: "playlists", label: "Playlists" },
+  { index: "users", label: "People" },
+];
+
+// Scope filter shown as a dropdown next to the query.
+type FilterKey = "all" | SearchIndex;
+
+const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "tracks", label: "Songs" },
+  { key: "albums", label: "Albums" },
+  { key: "artists", label: "Artists" },
+  { key: "playlists", label: "Playlists" },
+  { key: "users", label: "People" },
+];
+
+// ── Styling ─────────────────────────────────────────────────────────────────
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 12vh 16px 16px;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(3px);
+`;
+
+const Panel = styled.div`
+  width: 100%;
+  max-width: 640px;
+  max-height: 66vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-background);
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+`;
+
+const SearchRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.18);
+`;
+
+const QueryInput = styled.input`
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--color-text);
+  font-family: RockfordSansRegular;
+  font-size: 18px;
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+`;
+
+const EscHint = styled.kbd`
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  color: var(--color-text-muted);
+  padding: 4px 7px;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 6px;
+`;
+
+const FilterSelect = styled.select`
+  flex-shrink: 0;
+  font-family: RockfordSansRegular;
+  font-size: 13px;
+  color: var(--color-text);
+  background: var(--color-input-background);
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  border-radius: 8px;
+  padding: 6px 8px;
+  cursor: pointer;
+  outline: none;
+`;
+
+const Results = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 6px;
+`;
+
+const SectionLabel = styled.div`
+  font-family: RockfordSansBold;
+  font-size: 11px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  padding: 12px 12px 6px;
+`;
+
+const Row = styled.div<{ active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 9px;
+  cursor: pointer;
+  background: ${({ active }) =>
+    active ? "var(--color-menu-hover)" : "transparent"};
+`;
+
+const Thumb = styled.div<{ round?: boolean }>`
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: ${({ round }) => (round ? "50%" : "6px")};
+  overflow: hidden;
+  background: var(--color-skeleton-background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+`;
+
+const RowText = styled.div`
+  min-width: 0;
+  flex: 1;
+`;
+
+const Primary = styled.div`
+  color: var(--color-text);
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Secondary = styled.div<{ mono?: boolean }>`
+  color: var(--color-text-muted);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ${({ mono }) => (mono ? "var(--font-mono)" : "inherit")};
+`;
+
+const TypeBadge = styled.span`
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  border-radius: 5px;
+  padding: 3px 6px;
+`;
+
+const Empty = styled.div`
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 14px;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 9px 16px;
+  border-top: 1px solid rgba(128, 128, 128, 0.18);
+  color: var(--color-text-muted);
+  font-size: 12px;
+`;
+
+const FootHint = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 2px 6px;
+    border: 1px solid rgba(128, 128, 128, 0.3);
+    border-radius: 5px;
+  }
+`;
+
+const ICON_COLOR = "var(--color-text-muted)";
+
+function FallbackIcon({ kind }: { kind: SearchIndex }) {
+  switch (kind) {
+    case "users":
+      return <IconUser size={22} color={ICON_COLOR} />;
+    case "artists":
+      return <Artist color={ICON_COLOR} />;
+    case "albums":
+      return <Disc color={ICON_COLOR} width={22} height={22} />;
+    case "tracks":
+      return <Track color={ICON_COLOR} />;
+    case "playlists":
+      return <Playlist />;
+    default:
+      return null;
+  }
+}
+
+function Artwork({ item }: { item: NavItem }) {
+  const { art, primary } = item;
+  return (
+    <Thumb round={art.round}>
+      {art.url ? (
+        <img src={art.url} alt={primary} />
+      ) : (
+        <FallbackIcon kind={art.kind} />
+      )}
+    </Thumb>
+  );
+}
+
+// ── Palette (mounted only while open, so it initialises fresh each time) ──────
+
+function Palette({ onClose }: { onClose: () => void }) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<FilterKey>("all");
+  const [active, setActive] = useState(0);
+  const { mutate, data, reset } = useSearchMutation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const debounced = useMemo(
+    () => _.debounce((q: string) => mutate(q), 180),
+    [mutate],
+  );
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    return () => debounced.cancel();
+  }, [debounced]);
+
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      debounced.cancel();
+      reset();
+      return;
+    }
+    debounced(q);
+  }, [query, debounced, reset]);
+
+  // Group navigable hits by section, and keep a parallel flat list for
+  // arrow-key navigation (index into `flat` === visual order).
+  const { sections, flat } = useMemo(() => {
+    const items = (data?.hits ?? [])
+      .map(toNavItem)
+      .filter((x): x is NavItem => x !== null);
+    const byIndex = _.groupBy(items, (it) => it.index);
+    const built: { label: string; items: NavItem[] }[] = [];
+    const flatList: NavItem[] = [];
+    const visible =
+      filter === "all"
+        ? SECTION_ORDER
+        : SECTION_ORDER.filter((s) => s.index === filter);
+    for (const section of visible) {
+      const group = byIndex[section.index];
+      if (group && group.length) {
+        built.push({ label: section.label, items: group });
+        flatList.push(...group);
+      }
+    }
+    return { sections: built, flat: flatList };
+  }, [data, filter]);
+
+  // Reset the highlight to the top whenever the visible result set changes
+  // (new query or filter). `flat` is a fresh array each recompute, so its
+  // identity is the signal — adjust during render per the React "reset state
+  // when a value changes" pattern rather than in an effect.
+  const prevFlat = useRef(flat);
+  if (prevFlat.current !== flat) {
+    prevFlat.current = flat;
+    if (active !== 0) setActive(0);
+  }
+
+  // Keep the active row scrolled into view.
+  useEffect(() => {
+    rowRefs.current[active]?.scrollIntoView({ block: "nearest" });
+  }, [active]);
+
+  const go = (item: NavItem | undefined) => {
+    if (!item) return;
+    onClose();
+    navigate({ to: item.href as string });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((i) => (flat.length ? (i + 1) % flat.length : 0));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => (flat.length ? (i - 1 + flat.length) % flat.length : 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      go(flat[active]);
+    }
+  };
+
+  const trimmed = query.trim();
+  let flatIndex = -1;
+
+  return (
+    <Panel onClick={(e) => e.stopPropagation()}>
+      <SearchRow>
+        <SearchIcon size={22} color="var(--color-text-muted)" />
+        <QueryInput
+          ref={inputRef}
+          value={query}
+          placeholder="Search songs, artists, albums, people…"
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <FilterSelect
+          value={filter}
+          onChange={(e) => {
+            setFilter(e.target.value as FilterKey);
+            // Return focus to the query so arrow-key navigation resumes.
+            inputRef.current?.focus();
+          }}
+        >
+          {FILTER_OPTIONS.map((opt) => (
+            <option key={opt.key} value={opt.key}>
+              {opt.label}
+            </option>
+          ))}
+        </FilterSelect>
+        <EscHint>esc</EscHint>
+      </SearchRow>
+
+      {flat.length > 0 && (
+        <Results>
+          {sections.map((section) => (
+            <div key={section.label}>
+              <SectionLabel>{section.label}</SectionLabel>
+              {section.items.map((item) => {
+                flatIndex += 1;
+                const idx = flatIndex;
+                return (
+                  <Row
+                    key={item.id}
+                    active={idx === active}
+                    ref={(el) => {
+                      rowRefs.current[idx] = el;
+                    }}
+                    onMouseMove={() => setActive(idx)}
+                    onClick={() => go(item)}
+                  >
+                    <Artwork item={item} />
+                    <RowText>
+                      <Primary>{item.primary}</Primary>
+                      {item.secondary && (
+                        <Secondary mono={item.secondaryMono}>
+                          {item.secondary}
+                        </Secondary>
+                      )}
+                    </RowText>
+                    <TypeBadge>{item.typeLabel}</TypeBadge>
+                  </Row>
+                );
+              })}
+            </div>
+          ))}
+        </Results>
+      )}
+
+      {flat.length === 0 && (
+        <Empty>
+          {trimmed.length < 2
+            ? "Search songs, artists, albums, playlists and people."
+            : `No results for “${trimmed}”.`}
+        </Empty>
+      )}
+
+      <Footer>
+        <FootHint>
+          <kbd>↑</kbd>
+          <kbd>↓</kbd> navigate
+        </FootHint>
+        <FootHint>
+          <kbd>↵</kbd> open
+        </FootHint>
+        <FootHint>
+          <kbd>esc</kbd> close
+        </FootHint>
+      </Footer>
+    </Panel>
+  );
+}
+
+function SearchModal() {
+  const [open, setOpen] = useAtom(searchModalOpenAtom);
+
+  // Lock background scroll while the palette is open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <Overlay onClick={() => setOpen(false)}>
+      <Palette onClose={() => setOpen(false)} />
+    </Overlay>
+  );
+}
+
+export default SearchModal;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { themeAtom } from "../atoms/theme";
 import KeyboardShortcuts from "../components/KeyboardShortcuts";
 import StickyPlayer from "../components/StickyPlayer";
+import SearchModal from "../layouts/Search/SearchModal";
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -43,6 +44,7 @@ function RootComponent() {
       <Outlet />
       <StickyPlayer />
       <KeyboardShortcuts />
+      <SearchModal />
     </React.Fragment>
   );
 }

--- a/apps/web/src/types/search.ts
+++ b/apps/web/src/types/search.ts
@@ -1,0 +1,80 @@
+// Typed shape of the federated search response from
+// GET /xrpc/app.rocksky.feed.search. Each hit is a raw index document tagged
+// with the collection it came from via `_federation.indexUid`.
+
+export type SearchIndex =
+  | "users"
+  | "artists"
+  | "albums"
+  | "tracks"
+  | "playlists";
+
+type Federation<T extends SearchIndex> = { _federation: { indexUid: T } };
+
+export type UserHit = Federation<"users"> & {
+  id: string;
+  did: string;
+  handle: string;
+  displayName: string | null;
+  avatar: string;
+};
+
+export type ArtistHit = Federation<"artists"> & {
+  id: string;
+  name: string;
+  picture: string | null;
+  uri: string | null;
+};
+
+export type AlbumHit = Federation<"albums"> & {
+  id: string;
+  title: string;
+  artist: string;
+  albumArt: string | null;
+  uri: string | null;
+};
+
+export type TrackHit = Federation<"tracks"> & {
+  id: string;
+  title: string;
+  artist: string;
+  albumArtist: string;
+  album: string;
+  albumArt: string | null;
+  uri: string | null;
+};
+
+export type PlaylistHit = Federation<"playlists"> & {
+  id: string;
+  name: string;
+  picture: string | null;
+  uri: string | null;
+};
+
+export type SearchHit =
+  | UserHit
+  | ArtistHit
+  | AlbumHit
+  | TrackHit
+  | PlaylistHit;
+
+export interface SearchResponse {
+  hits: SearchHit[];
+  processingTimeMs: number;
+  limit: number;
+  offset: number;
+  estimatedTotalHits: number;
+}
+
+// Type guards — the discriminant lives on the nested `_federation.indexUid`,
+// which TS can't narrow through a plain switch, so narrow explicitly.
+export const isUserHit = (h: SearchHit): h is UserHit =>
+  h._federation.indexUid === "users";
+export const isArtistHit = (h: SearchHit): h is ArtistHit =>
+  h._federation.indexUid === "artists";
+export const isAlbumHit = (h: SearchHit): h is AlbumHit =>
+  h._federation.indexUid === "albums";
+export const isTrackHit = (h: SearchHit): h is TrackHit =>
+  h._federation.indexUid === "tracks";
+export const isPlaylistHit = (h: SearchHit): h is PlaylistHit =>
+  h._federation.indexUid === "playlists";


### PR DESCRIPTION
Replace the inline search popover with a full command palette (web only; web-mobile keeps its own search). Opened by clicking the sidebar search field or pressing "/".

- Grouped results (Songs/Artists/Albums/Playlists/People) with artwork, a scope filter dropdown (All + per-type), and full keyboard navigation (arrows, Enter to open, Esc to close)
- Reuses the existing AT-URI -> path routing so navigation is unchanged
- Types the federated search response (SearchResponse union + guards), replacing the old any[]
- Wires "/" and Esc through the global keyboard-shortcut handler