### PR TITLE
Enable CLI playback control via web/mobile miniplayers

### DIFF
--- a/apps/api/src/websocket/handler.ts
+++ b/apps/api/src/websocket/handler.ts
@@ -273,11 +273,19 @@ function handleWebsocket(c: Context) {
           }
 
           // ── Broadcast enriched data to all connected devices ──
+          // Include the source device's name so miniplayers can label which
+          // device is playing (e.g. "Rocksky CLI") rather than a generic source.
+          const deviceName = deviceNames[device_id] ?? deviceNames[ws.deviceId];
           userDevices[did]?.forEach((id) => {
             const targetDevice = devices[id];
             if (targetDevice) {
               targetDevice.send(
-                JSON.stringify({ type: "message", data, device_id }),
+                JSON.stringify({
+                  type: "message",
+                  data,
+                  device_id,
+                  device_name: deviceName,
+                }),
               );
             }
           });

--- a/apps/cli/src/tui/rockskyWs.ts
+++ b/apps/cli/src/tui/rockskyWs.ts
@@ -1,0 +1,271 @@
+// Rocksky remote: makes the CLI player a controllable WebSocket device on the
+// Rocksky relay (GET /ws), exactly like the Rust `connect` daemon and the
+// browser miniplayers. It
+//   • registers as "Rocksky CLI" using the cached access token,
+//   • pushes now-playing (track) + transport (status) from `playerController`,
+//   • executes play/pause/next/previous/seek commands sent from the web/mobile
+//     miniplayers.
+// The relay scopes everything by the token's DID and broadcasts our state to
+// the user's other devices, so the CLI and the miniplayers stay in sync.
+//
+// Deliberately silent on stdout: the TUI renders with Ink, so any console
+// output would corrupt the screen. Set ROCKSKY_WS_DEBUG=1 for stderr tracing.
+
+import { ROCKSKY_API_URL } from "client";
+import { skipNext, skipPrev } from "./playback";
+import { playerController } from "./player";
+import { loadSettings } from "./settings";
+
+const WS_URL =
+  process.env.ROCKSKY_WS ||
+  `${ROCKSKY_API_URL.replace(/^http/, "ws")}/ws`;
+
+// Poll cadence for pushing state, and how often we re-push the current track so
+// remote elapsed can't drift far from ours (the miniplayers tick progress
+// locally between our pushes and reconcile on each one).
+const PUSH_INTERVAL_MS = 1000;
+const TRACK_REPUSH_MS = 4000;
+const HEARTBEAT_MS = 10_000;
+const RECONNECT_MS = 3000;
+
+function debug(...args: unknown[]) {
+  if (process.env.ROCKSKY_WS_DEBUG) console.error("[rocksky-ws]", ...args);
+}
+
+// PlayerStatus.state → the numeric status the relay/miniplayers expect.
+function statusCode(state: "stopped" | "playing" | "paused"): number {
+  return state === "playing" ? 1 : state === "paused" ? 2 : 0;
+}
+
+export interface RockskyRemote {
+  stop(): void;
+}
+
+/**
+ * Connect the shared `playerController` to the Rocksky relay. `getToken` is read
+ * on every connect/send so a login mid-session takes effect and a logout stops
+ * traffic. Returns a handle whose `stop()` tears the connection down.
+ */
+export function startRockskyRemote(
+  getToken: () => string | undefined,
+): RockskyRemote {
+  if (process.env.ROCKSKY_NO_REMOTE) {
+    return { stop() {} };
+  }
+
+  let ws: WebSocket | null = null;
+  let deviceId = "";
+  let stopped = false;
+  let pushTimer: ReturnType<typeof setInterval> | undefined;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Last state we broadcast, so we only push on change (plus the re-push timer).
+  let lastStatusCode = -1;
+  let lastTrackKey = "";
+  let lastTrackPushAt = 0;
+
+  const send = (payload: unknown) => {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify(payload));
+      } catch (e) {
+        debug("send error", e);
+      }
+    }
+  };
+
+  // Build and push the current now-playing track message. `force` bypasses the
+  // change/interval gates (used right after a command so clients update fast).
+  const pushTrack = (force = false) => {
+    const token = getToken();
+    if (!token || !deviceId) return;
+    const status = playerController.status();
+    const item = playerController.currentItem();
+    if (!status || !item || status.state === "stopped") return;
+
+    const durationMs = status.duration_ms || item.duration || 0;
+    const elapsedMs = status.position_ms || 0;
+    const key = `${item.title}|${item.artist}|${item.album ?? ""}|${status.index}`;
+    const now = Date.now();
+    if (!force && key === lastTrackKey && now - lastTrackPushAt < TRACK_REPUSH_MS)
+      return;
+    lastTrackKey = key;
+    lastTrackPushAt = now;
+
+    send({
+      type: "message",
+      device_id: deviceId,
+      token,
+      data: {
+        type: "track",
+        title: item.title,
+        artist: item.artist,
+        album: item.album,
+        album_artist: item.albumArtist || item.artist,
+        length: durationMs,
+        elapsed: elapsedMs,
+        duration_ms: durationMs,
+        album_art: item.albumArt,
+      },
+    });
+  };
+
+  const pushStatus = (code: number) => {
+    const token = getToken();
+    if (!token || !deviceId) return;
+    send({
+      type: "message",
+      device_id: deviceId,
+      token,
+      data: { type: "status", status: code },
+    });
+  };
+
+  // One tick: emit status transitions immediately, and the current track on
+  // change or every TRACK_REPUSH_MS while playing.
+  const tick = () => {
+    const status = playerController.status();
+    const code = statusCode(status?.state ?? "stopped");
+    if (code !== lastStatusCode) {
+      lastStatusCode = code;
+      pushStatus(code);
+      if (code === 0) lastTrackKey = ""; // force a fresh track push on resume
+    }
+    if (code !== 0) pushTrack();
+  };
+
+  const handleCommand = async (msg: {
+    action?: string;
+    args?: unknown;
+    position?: number;
+  }) => {
+    const token = getToken();
+    switch (msg.action) {
+      case "play":
+        playerController.play();
+        break;
+      case "pause":
+        playerController.pause();
+        break;
+      case "next":
+        if (token) await skipNext(token);
+        else playerController.next();
+        break;
+      case "previous":
+        if (token) await skipPrev(token);
+        else playerController.previous();
+        break;
+      case "seek": {
+        // The relay forwards only {type, action, args}, so a seek position must
+        // ride in `args` (a number, or { position }). `position` is accepted too
+        // for clients that send it top-level.
+        const a = msg.args as { position?: number } | number | undefined;
+        const pos =
+          typeof a === "number"
+            ? a
+            : (a?.position ?? msg.position ?? 0);
+        playerController.seekMs(pos);
+        break;
+      }
+      default:
+        debug("unknown command", msg.action);
+        return;
+    }
+    // Reflect the new state to every device without waiting for the next tick.
+    lastStatusCode = -1;
+    setTimeout(() => {
+      tick();
+      pushTrack(true);
+    }, 50);
+  };
+
+  const connect = () => {
+    if (stopped) return;
+    const token = getToken();
+    if (!token) {
+      // Not logged in yet — retry shortly so a later `rocksky login` connects.
+      reconnectTimer = setTimeout(connect, RECONNECT_MS);
+      return;
+    }
+
+    debug("connecting to", WS_URL);
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(WS_URL);
+    } catch (e) {
+      debug("connect failed", e);
+      reconnectTimer = setTimeout(connect, RECONNECT_MS);
+      return;
+    }
+    ws = socket;
+
+    socket.onopen = () => {
+      debug("connected");
+      // The advertised name is configurable via ~/.rocksky/settings.toml
+      // ([remote] name = "…"); read fresh on each connect so edits take effect.
+      const clientName = loadSettings().remote.name;
+      send({ type: "register", clientName, token: getToken() });
+      heartbeatTimer = setInterval(() => {
+        if (socket.readyState === WebSocket.OPEN) socket.send("ping");
+      }, HEARTBEAT_MS);
+    };
+
+    socket.onmessage = (event) => {
+      let msg: Record<string, unknown>;
+      try {
+        if (event.data === "pong") return;
+        msg = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+      // Registration reply carries our device id.
+      if (typeof msg.deviceId === "string") {
+        deviceId = msg.deviceId;
+        debug("registered", deviceId);
+        // Start pushing state now that we have an id.
+        lastStatusCode = -1;
+        lastTrackKey = "";
+        tick();
+        pushTrack(true);
+        if (!pushTimer) pushTimer = setInterval(tick, PUSH_INTERVAL_MS);
+        return;
+      }
+      if (msg.type === "command") {
+        void handleCommand(msg as { action?: string; args?: unknown });
+      }
+      // `type: "message"` broadcasts (our own state echoed back, or another
+      // device's) are ignored — the CLI is the player, not a controller.
+    };
+
+    socket.onerror = (e) => debug("socket error", e);
+
+    socket.onclose = () => {
+      debug("disconnected");
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (pushTimer) clearInterval(pushTimer);
+      heartbeatTimer = undefined;
+      pushTimer = undefined;
+      ws = null;
+      deviceId = "";
+      if (!stopped) reconnectTimer = setTimeout(connect, RECONNECT_MS);
+    };
+  };
+
+  connect();
+
+  return {
+    stop() {
+      stopped = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (pushTimer) clearInterval(pushTimer);
+      try {
+        ws?.close();
+      } catch {
+        /* ignore */
+      }
+      ws = null;
+    },
+  };
+}

--- a/apps/cli/src/tui/runtime.ts
+++ b/apps/cli/src/tui/runtime.ts
@@ -4,6 +4,7 @@
 
 import { prefetchTick } from "./playback";
 import { playerController } from "./player";
+import { startRockskyRemote } from "./rockskyWs";
 import { scrobblerTick } from "./scrobbler";
 import { loadSession, saveSession } from "./session";
 import { loadSettings, saveSettings } from "./settings";
@@ -50,11 +51,16 @@ export function startHeadlessRuntime(
     prefetchTick(token);
   }, 2000);
 
+  // Expose the player to the web/mobile miniplayers as a controllable device,
+  // and mirror its now-playing there in real time.
+  const remote = startRockskyRemote(getToken);
+
   return {
     stop() {
       clearInterval(sessionSaver);
       clearInterval(ticker);
       clearTimeout(saveTimer);
+      remote.stop();
       playerController.onSettingsChange = null;
       // Flush the latest settings + session on the way out.
       saveSettings(playerController.snapshotSettings());

--- a/apps/cli/src/tui/settings.ts
+++ b/apps/cli/src/tui/settings.ts
@@ -16,6 +16,11 @@ export interface Settings {
     port: number;
     bind: string;
   };
+  // How this player advertises itself to the web/mobile miniplayers over the
+  // /ws relay. `name` is the label shown in their source selector.
+  remote: {
+    name: string;
+  };
   equalizer: {
     enabled: boolean;
     bands: number[];
@@ -41,6 +46,9 @@ export const DEFAULT_SETTINGS: Settings = {
     enabled: false,
     port: 6600,
     bind: "127.0.0.1",
+  },
+  remote: {
+    name: "Rocksky CLI",
   },
   equalizer: {
     enabled: false,
@@ -108,6 +116,9 @@ function serialize(s: Settings): string {
     `port = ${s.mpd.port}`,
     `bind = "${s.mpd.bind}"`,
     ``,
+    `[remote]`,
+    `name = "${s.remote.name}"`,
+    ``,
     `[equalizer]`,
     `enabled = ${s.equalizer.enabled}`,
     `bands = [${s.equalizer.bands.join(", ")}]`,
@@ -135,6 +146,7 @@ export function loadSettings(): Settings {
     const parsed = parseToml(fs.readFileSync(settingsPath(), "utf-8"));
     const eq = parsed.equalizer || {};
     const mpd = parsed.mpd || {};
+    const remote = parsed.remote || {};
     const bands = Array.isArray(eq.bands)
       ? DEFAULT_SETTINGS.equalizer.bands.map((d, i) => num(eq.bands[i], d))
       : DEFAULT_SETTINGS.equalizer.bands;
@@ -149,6 +161,12 @@ export function loadSettings(): Settings {
         port: num(mpd.port, DEFAULT_SETTINGS.mpd.port),
         bind:
           typeof mpd.bind === "string" ? mpd.bind : DEFAULT_SETTINGS.mpd.bind,
+      },
+      remote: {
+        name:
+          typeof remote.name === "string" && remote.name.trim().length > 0
+            ? remote.name
+            : DEFAULT_SETTINGS.remote.name,
       },
       equalizer: {
         enabled: bool(eq.enabled, false),
@@ -171,14 +189,17 @@ export function loadSettings(): Settings {
   }
 }
 
-// The player only owns the playback settings; the [mpd] section is config the
-// player never mutates. Accept playback settings and preserve [mpd] from disk
-// so a playback-triggered save doesn't clobber the user's MPD config.
-export function saveSettings(s: Omit<Settings, "mpd">): void {
+// The player only owns the playback settings; the [mpd] and [remote] sections
+// are config the player never mutates. Accept playback settings and preserve
+// those sections from disk so a playback-triggered save doesn't clobber them.
+export function saveSettings(s: Omit<Settings, "mpd" | "remote">): void {
   try {
-    const mpd = loadSettings().mpd;
+    const disk = loadSettings();
     fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
-    fs.writeFileSync(settingsPath(), serialize({ ...s, mpd }));
+    fs.writeFileSync(
+      settingsPath(),
+      serialize({ ...s, mpd: disk.mpd, remote: disk.remote }),
+    );
   } catch {
     // best-effort; ignore write errors
   }

--- a/apps/web-mobile/src/components/MiniPlayer/index.tsx
+++ b/apps/web-mobile/src/components/MiniPlayer/index.tsx
@@ -53,6 +53,7 @@ function SourceSheet({
   onClose,
   player,
   rockboxAvailable,
+  rockboxLabel,
   queueLength,
   onSelect,
 }: {
@@ -60,6 +61,7 @@ function SourceSheet({
   onClose: () => void;
   player: string | null;
   rockboxAvailable: boolean;
+  rockboxLabel: string;
   queueLength: number;
   onSelect: (src: "spotify" | "rockbox" | "upload") => void;
 }) {
@@ -85,7 +87,7 @@ function SourceSheet({
           </button>
         </div>
         {rockboxAvailable && (
-          <SourceItem label="Rockbox" active={player === "rockbox"} onClick={() => { onSelect("rockbox"); onClose(); }} />
+          <SourceItem label={rockboxLabel} active={player === "rockbox"} onClick={() => { onSelect("rockbox"); onClose(); }} />
         )}
         {queueLength > 0 && (
           <SourceItem label="My Library" active={player === "upload"} onClick={() => { onSelect("upload"); onClose(); }} />
@@ -151,6 +153,9 @@ export default function MiniPlayer() {
   const [liked, setLiked] = useState<Record<string, boolean>>({});
   const likedRef = useRef(liked);
   const [rockboxAvailable, setRockboxAvailable] = useState(false);
+  // Name of the remote device currently reporting (e.g. "Rocksky CLI"), shown
+  // in the source sheet instead of a generic label.
+  const [deviceName, setDeviceName] = useState("Rockbox");
   const [sourceSheetOpen, setSourceSheetOpen] = useState(false);
   const [eqSheetOpen, setEqSheetOpen] = useState(false);
   const [shuffle, setShuffle] = useAtom(shuffleAtom);
@@ -303,6 +308,7 @@ export default function MiniPlayer() {
 
         if (msg.type === "message" && msg.data?.type === "track") {
           setRockboxAvailable(true);
+          if (msg.device_name) setDeviceName(msg.device_name);
           if (playerRef.current !== null && playerRef.current !== "rockbox") return;
           if (lastFetchedRef.current && Date.now() - lastFetchedRef.current < 3000) return;
           if (!msg.data.title && !msg.data.artist && !msg.data.album_artist) return;
@@ -394,6 +400,12 @@ export default function MiniPlayer() {
   };
 
   const onPrevious = () => {
+    if (player === "rockbox" && socketRef.current) {
+      socketRef.current.send(JSON.stringify({
+        type: "command", action: "previous", token: localStorage.getItem("token"),
+      }));
+      return;
+    }
     if (player !== "upload") return;
     getRockboxPlayer().prev();
   };
@@ -402,6 +414,14 @@ export default function MiniPlayer() {
     if (playerRef.current === "upload") {
       const p = getRockboxPlayer();
       if (p.ready) p.seek(positionMs);
+    } else if (playerRef.current === "rockbox" && socketRef.current) {
+      // Seek position rides in `args` — the relay forwards only {type, action, args}.
+      socketRef.current.send(JSON.stringify({
+        type: "command",
+        action: "seek",
+        args: { position: positionMs },
+        token: localStorage.getItem("token"),
+      }));
     }
     setNowPlaying((prev) => prev ? { ...prev, progress: positionMs } : prev);
   }, [setNowPlaying]);
@@ -557,6 +577,7 @@ export default function MiniPlayer() {
         onClose={() => setSourceSheetOpen(false)}
         player={player}
         rockboxAvailable={rockboxAvailable}
+        rockboxLabel={deviceName}
         queueLength={queue.length}
         onSelect={(src) => {
           if (src === "upload" && player !== "upload") {

--- a/apps/web/src/atoms/player.ts
+++ b/apps/web/src/atoms/player.ts
@@ -1,3 +1,8 @@
 import { atom } from "jotai";
 
-export const playerAtom = atom<"rockbox" | "spotify" | null>(null);
+// "rockbox" = the in-browser wasm engine (local playback).
+// "spotify"  = the connected Spotify account (polled).
+// "device"   = a remote controllable device on the /ws relay (the Rocksky CLI,
+//              or the Rockbox companion daemon) — now-playing arrives over the
+//              socket and transport is sent back as commands.
+export const playerAtom = atom<"rockbox" | "spotify" | "device" | null>(null);

--- a/apps/web/src/components/StickyPlayer/StickyPlayerWithData.tsx
+++ b/apps/web/src/components/StickyPlayer/StickyPlayerWithData.tsx
@@ -116,6 +116,13 @@ function StickyPlayerWithData() {
   const playerRef = useRef(player);
   const likedRef = useRef(liked);
   const profile = useAtomValue(profileAtom);
+  // Remote controllable device (the Rocksky CLI, or the Rockbox daemon) on the
+  // /ws relay: now-playing streams in over the socket and transport is sent back
+  // as commands, so the web miniplayer stays in sync with the device.
+  const socketRef = useRef<WebSocket | null>(null);
+  const heartbeatRef = useRef<number | null>(null);
+  const [deviceAvailable, setDeviceAvailable] = useState(false);
+  const [deviceName, setDeviceName] = useState("Remote device");
   // Hidden silent <audio> that plays while the wasm engine plays, so the
   // browser surfaces the Media Session / OS media controls (Web Audio alone
   // doesn't trigger them).
@@ -155,15 +162,18 @@ function StickyPlayerWithData() {
     publishRepeat(repeatMode === "one" ? 1 : repeatMode === "all" ? 2 : 0);
   }, [repeatMode]);
 
-  // Progress ticker for Spotify only — rockbox progress comes from the engine's
-  // `progress` events, so skip it here to avoid double-counting.
+  // Progress ticker for Spotify and remote devices — rockbox progress comes
+  // from the engine's own `progress` events, so skip it there to avoid double-
+  // counting. For a remote device we tick locally between the device's periodic
+  // now-playing pushes (which reconcile any drift).
   useEffect(() => {
     const id = window.setInterval(() => {
       setNowPlaying((prev) => {
         if (!prev || !prev.isPlaying) return prev;
-        if (playerRef.current !== "spotify") return prev;
+        const p = playerRef.current;
+        if (p !== "spotify" && p !== "device") return prev;
         if (prev.progress >= prev.duration) {
-          setTimeout(fetchCurrentlyPlaying, 2000);
+          if (p === "spotify") setTimeout(fetchCurrentlyPlaying, 2000);
           return prev;
         }
         return { ...prev, progress: prev.progress + 100 };
@@ -177,7 +187,7 @@ function StickyPlayerWithData() {
 
   const fetchCurrentlyPlaying = useCallback(async () => {
     const currentPlayer = playerRef.current;
-    if (currentPlayer === "rockbox") return;
+    if (currentPlayer === "rockbox" || currentPlayer === "device") return;
     const { data } = await axios.get(`${API_URL}/spotify/currently-playing`, {
       headers: { authorization: `Bearer ${localStorage.getItem("token")}` },
     });
@@ -213,9 +223,99 @@ function StickyPlayerWithData() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // ── Remote device over the /ws relay ──────────────────────────────────────
+  // Send a transport command to the active device. Seek carries its position in
+  // `args` because the relay forwards only { type, action, args }.
+  const sendDeviceCommand = useCallback((action: string, args?: unknown) => {
+    const ws = socketRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({
+      type: "command",
+      action,
+      args,
+      token: localStorage.getItem("token"),
+    }));
+  }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+    const wsUrl = API_URL.replace("https", "wss").replace("http", "ws");
+    const ws = new WebSocket(`${wsUrl}/ws`);
+    socketRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "register", clientName: "rocksky-web", token }));
+      heartbeatRef.current = window.setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) ws.send("ping");
+      }, 10000);
+    };
+
+    ws.onmessage = (event) => {
+      if (event.data === "pong") return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let msg: any;
+      try { msg = JSON.parse(event.data); } catch { return; }
+
+      // A device is announcing now-playing → make it selectable and, unless the
+      // user is on another source, adopt it as the active player.
+      if (msg.type === "message" && msg.data?.type === "track") {
+        setDeviceAvailable(true);
+        if (msg.device_name) setDeviceName(msg.device_name);
+        if (playerRef.current !== null && playerRef.current !== "device") return;
+        if (lastFetchedRef.current && Date.now() - lastFetchedRef.current < 3000) return;
+        if (!msg.data.title && !msg.data.artist && !msg.data.album_artist) return;
+        setNowPlaying({
+          title: msg.data.title,
+          artist: msg.data.album_artist || msg.data.artist,
+          artistUri: msg.data.artist_uri ?? "",
+          songUri: msg.data.song_uri ?? "",
+          albumUri: msg.data.album_uri ?? "",
+          duration: msg.data.length,
+          progress: msg.data.elapsed,
+          albumArt: _.get(msg, "data.album_art"),
+          isPlaying: nowPlayingRef.current?.isPlaying ?? true,
+          sha256: msg.data.sha256 ?? "",
+          liked:
+            likedRef.current[msg.data.song_uri] !== undefined
+              ? likedRef.current[msg.data.song_uri]
+              : !!msg.data.liked,
+        });
+        setPlayer("device");
+        lastFetchedRef.current = Date.now();
+        return;
+      }
+
+      // Transport status only matters while the device is the active player.
+      if (playerRef.current !== "device") return;
+      if (msg.data?.type === "status") {
+        const s = msg.data.status;
+        if (s === 0) { setNowPlaying(null); setPlayer((p) => (p === "device" ? null : p)); }
+        else if (s === 1) setNowPlaying((prev) => prev ? { ...prev, isPlaying: true } : prev);
+        else if (s === 2 || s === 3) setNowPlaying((prev) => prev ? { ...prev, isPlaying: false } : prev);
+      }
+    };
+
+    ws.onclose = () => {
+      if (heartbeatRef.current) clearInterval(heartbeatRef.current);
+    };
+
+    return () => {
+      if (heartbeatRef.current) clearInterval(heartbeatRef.current);
+      ws.close();
+      socketRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // ── Playback controls ─────────────────────────────────────────────────────
 
   const onPlay = async () => {
+    if (player === "device") {
+      sendDeviceCommand("play");
+      setNowPlaying((prev) => prev ? { ...prev, isPlaying: true } : prev);
+      return;
+    }
     if (player === "rockbox") {
       const p = await ensureRockboxReady();
       // Resume after a reload: the queue was rehydrated from localStorage but
@@ -250,6 +350,11 @@ function StickyPlayerWithData() {
   };
 
   const onPause = () => {
+    if (player === "device") {
+      sendDeviceCommand("pause");
+      setNowPlaying((prev) => prev ? { ...prev, isPlaying: false } : prev);
+      return;
+    }
     if (player === "rockbox") {
       getRockboxPlayer().pause();
       setNowPlaying((prev) => prev ? { ...prev, isPlaying: false } : prev);
@@ -259,6 +364,10 @@ function StickyPlayerWithData() {
   };
 
   const onNext = () => {
+    if (player === "device") {
+      sendDeviceCommand("next");
+      return;
+    }
     if (player === "rockbox") {
       getRockboxPlayer().next();
       return;
@@ -267,6 +376,10 @@ function StickyPlayerWithData() {
   };
 
   const onPrevious = () => {
+    if (player === "device") {
+      sendDeviceCommand("previous");
+      return;
+    }
     if (player === "rockbox") {
       getRockboxPlayer().prev();
       return;
@@ -275,6 +388,11 @@ function StickyPlayerWithData() {
   };
 
   const onSeek = (position: number) => {
+    if (player === "device") {
+      sendDeviceCommand("seek", { position });
+      setNowPlaying((prev) => prev ? { ...prev, progress: position } : prev);
+      return;
+    }
     if (player === "rockbox") {
       getRockboxPlayer().seek(position);
       setNowPlaying((prev) => prev ? { ...prev, progress: position } : prev);
@@ -288,6 +406,8 @@ function StickyPlayerWithData() {
   const onVolumeChange = (v: number) => {
     setVolumeState(v);
     if (v > 0 && muted) setMutedState(false);
+    // A remote device manages its own volume — don't spin up the local engine.
+    if (player === "device") return;
     const p = getRockboxPlayer();
     if (p.ready) p.setVolume(muted ? 0 : v);
   };
@@ -295,6 +415,7 @@ function StickyPlayerWithData() {
   const onToggleMute = () => {
     const nextMuted = !muted;
     setMutedState(nextMuted);
+    if (player === "device") return;
     const p = getRockboxPlayer();
     if (p.ready) p.setVolume(nextMuted ? 0 : volume);
   };
@@ -551,6 +672,20 @@ function StickyPlayerWithData() {
                 <PlayerDot active={isRockbox} />
                 Rockbox
               </PlayerSelectorItem>
+              {deviceAvailable && (
+                <PlayerSelectorItem
+                  active={player === "device"}
+                  onClick={() => {
+                    // Silence the local engine before handing off to the device.
+                    if (player === "rockbox") getRockboxPlayer().pause();
+                    setPlayer("device");
+                    setPlayerSelectorOpen(false);
+                  }}
+                >
+                  <PlayerDot active={player === "device"} />
+                  {deviceName}
+                </PlayerSelectorItem>
+              )}
             </PlayerSelectorPopup>
           </>,
           document.body,

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -51,3 +51,23 @@ rocksky stats                        # listening stats
 | [`scrobble-api`](/cli/scrobble-api)             | Run a local Last.fm / ListenBrainz-compatible server       |
 | [`mpd`](/cli/mpd)                               | Serve your library over the MPD protocol                   |
 | [`help`](/cli/help)                             | Show help for any command                                  |
+
+## Remote control
+
+Whenever the CLI player is running (the interactive TUI, or the
+[`mpd`](/cli/mpd) daemon), it connects to Rocksky over a WebSocket and appears
+as a controllable device in the Rocksky web and mobile miniplayers — just like
+the Rockbox companion. What you play on the CLI shows up there in real time, and
+play / pause / next / previous / seek from the miniplayer drive the CLI, with
+elapsed time kept in sync both ways. It authenticates with the same session
+token from `rocksky login`, so no extra setup is needed.
+
+The name shown in the miniplayer's source selector is configurable in
+`~/.rocksky/settings.toml`:
+
+```toml
+[remote]
+name = "Living Room"
+```
+
+Set `ROCKSKY_NO_REMOTE=1` to disable the connection entirely.


### PR DESCRIPTION
Make the Rocksky CLI player a controllable device on the /ws relay, like the Rockbox companion: it registers with the session token, streams its now-playing (track + status) to the web/mobile miniplayers, and executes play/pause/next/previous/seek commands from them — elapsed time stays in sync both ways.

- cli: new tui/rockskyWs.ts (register, push state, handle commands), wired into startHeadlessRuntime so it runs for the TUI and `mpd` daemon. Device name is configurable via [remote] name in settings.toml (default "Rocksky CLI"); ROCKSKY_NO_REMOTE disables it.
- api: include device_name in ws broadcasts so clients can label the source.
- web: add a "device" player source to StickyPlayer — remote now-playing, live progress, and transport sent back as commands.
- web-mobile: label the remote source with device_name; add remote previous + seek.